### PR TITLE
feat(linters): implement output parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,17 +3,19 @@ module github.com/smykla-labs/klaudiush
 go 1.25.4
 
 require (
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/go-git/go-git/v6 v6.0.0-20251123213212-d5ca7ab6ebf9
 	github.com/google/go-github/v79 v79.0.0
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2
+	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.10.1
+	golang.org/x/sync v0.18.0
 	mvdan.cc/sh/v3 v3.12.0
 )
 
 require (
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.3.0 // indirect
 	github.com/cloudflare/circl v1.6.1 // indirect
@@ -30,7 +32,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kevinburke/ssh_config v1.4.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pjbgf/sha1cd v0.5.0 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
@@ -38,7 +39,6 @@ require (
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/mod v0.30.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
-	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	golang.org/x/tools v0.39.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,6 @@ github.com/go-git/go-billy/v6 v6.0.0-20251120215217-80673c4ccbfb h1:DMxvYQ9F7gtl
 github.com/go-git/go-billy/v6 v6.0.0-20251120215217-80673c4ccbfb/go.mod h1:0NjwVNrwtVFZBReAp5OoGklGJIgJFEbVyHneAr4lc8k=
 github.com/go-git/go-git-fixtures/v5 v5.1.1 h1:OH8i1ojV9bWfr0ZfasfpgtUXQHQyVS8HXik/V1C099w=
 github.com/go-git/go-git-fixtures/v5 v5.1.1/go.mod h1:Altk43lx3b1ks+dVoAG2300o5WWUnktvfY3VI6bcaXU=
-github.com/go-git/go-git/v6 v6.0.0-20251121083746-39fcec474970 h1:fTBItLbjioU31giAolw2Kfg91P/LmLcXH7stoJSQXLc=
-github.com/go-git/go-git/v6 v6.0.0-20251121083746-39fcec474970/go.mod h1:82JGB4xCU6W8toVHjEcv4KH4GSiB+MhjFTCGQxPOLdM=
 github.com/go-git/go-git/v6 v6.0.0-20251123213212-d5ca7ab6ebf9 h1:VxncWRyP5Z60WyYpc4fNEiM4+b+QRpJLiYh43fClp5k=
 github.com/go-git/go-git/v6 v6.0.0-20251123213212-d5ca7ab6ebf9/go.mod h1:dIwT3uWK1ooHInyVnK2JS5VfQ3peVGYaw2QPqX7uFvs=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=

--- a/internal/linters/runner.go
+++ b/internal/linters/runner.go
@@ -1,0 +1,77 @@
+package linters
+
+import (
+	"context"
+
+	execpkg "github.com/smykla-labs/klaudiush/internal/exec"
+)
+
+// OutputParser is a function that parses command output into LintFindings
+type OutputParser func(output string) []LintFinding
+
+// ContentLinter provides common functionality for content-based linters
+type ContentLinter struct {
+	runner      execpkg.CommandRunner
+	toolChecker execpkg.ToolChecker
+	tempManager execpkg.TempFileManager
+}
+
+// NewContentLinter creates a new ContentLinter
+func NewContentLinter(runner execpkg.CommandRunner) *ContentLinter {
+	return &ContentLinter{
+		runner:      runner,
+		toolChecker: execpkg.NewToolChecker(),
+		tempManager: execpkg.NewTempFileManager(),
+	}
+}
+
+// LintContent validates content using a CLI tool
+// toolName: the command to run
+// tempPattern: pattern for temp file (e.g., "script-*.sh")
+// content: the content to validate
+// parser: function to parse the output into findings
+// args: additional arguments for the tool (temp file path is appended)
+func (l *ContentLinter) LintContent(
+	ctx context.Context,
+	toolName string,
+	tempPattern string,
+	content string,
+	parser OutputParser,
+	args ...string,
+) *LintResult {
+	// Check if tool is available
+	if !l.toolChecker.IsAvailable(toolName) {
+		return &LintResult{
+			Success: true,
+			Err:     nil,
+		}
+	}
+
+	// Create temp file for validation
+	tmpFile, cleanup, err := l.tempManager.Create(tempPattern, content)
+	if err != nil {
+		return &LintResult{
+			Success: false,
+			Err:     err,
+		}
+	}
+	defer cleanup()
+
+	// Build full args with temp file path
+	fullArgs := make([]string, len(args)+1)
+	copy(fullArgs, args)
+	fullArgs[len(args)] = tmpFile
+
+	// Run tool
+	result := l.runner.Run(ctx, toolName, fullArgs...)
+
+	rawOut := result.Stdout + result.Stderr
+	findings := parser(result.Stdout)
+
+	return &LintResult{
+		Success:  result.Err == nil,
+		RawOut:   rawOut,
+		Findings: findings,
+		Err:      result.Err,
+	}
+}

--- a/internal/linters/shellcheck_test.go
+++ b/internal/linters/shellcheck_test.go
@@ -76,10 +76,11 @@ var _ = Describe("ShellChecker", func() {
 			It("should return success", func() {
 				mockRunner.runFunc = func(_ context.Context, name string, args ...string) execpkg.CommandResult {
 					Expect(name).To(Equal("shellcheck"))
-					Expect(args).To(HaveLen(1))
+					Expect(args).To(HaveLen(2))
+					Expect(args[0]).To(Equal("--format=json"))
 
 					return execpkg.CommandResult{
-						Stdout:   "",
+						Stdout:   "[]",
 						Stderr:   "",
 						ExitCode: 0,
 						Err:      nil,


### PR DESCRIPTION
## Motivation

The linters (shellcheck, actionlint, tflint) were running but returning empty `[]LintFinding{}` arrays. Users only saw pass/fail status without specific line numbers or actionable details. Additionally, version comparison for GitHub actions used string comparison which fails for edge cases like `v1.10.0` vs `v1.9.0`.

## Implementation information

- Parse shellcheck JSON output with `--format=json` flag
- Parse actionlint text output with regex pattern
- Parse tflint compact format output
- Extract `ContentLinter` helper to reduce ~60 lines of duplication
- Add semver comparison using `Masterminds/semver/v3` (already indirect dep)

## Supporting documentation

N/A

## Test plan

- [x] All existing tests pass (336 tests)
- [x] Updated shellcheck test for new `--format=json` argument
- [x] Lint passes with no issues