### PR TITLE
ci(scorecard): fix annotated tag commit hash

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Motivation

The Scorecard workflow was failing with "imposter commit" error when publishing results to the OSSF API.

## Implementation information

- Use actual commit SHA instead of annotated tag object SHA for `ossf/scorecard-action@v2.4.3`

The v2.4.3 tag is an annotated tag with two SHAs:

- Tag object: `99c09fe975337306107572b4fdf4db224cf8e2f2` (was incorrectly used)
- Commit: `4eaacf0543bb3f2c246792bd56e8cdeffafb205a` (correct)

The Scorecard webapp validates commit hashes against actual repository commits when `publish_results: true`, rejecting tag object SHAs as "imposter commits".

> Changelog: skip