### PR TITLE
ci(claude): configure on-demand Claude review triggers

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -106,15 +106,10 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            Please review pull request #${{ needs.check-trigger.outputs.pr_number }} in ${{ github.repository }} and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
+            Review PR #${{ needs.check-trigger.outputs.pr_number }} in ${{ github.repository }}.
 
-            Use the repository's CLAUDE.md for guidance on style and conventions.
-            Be constructive and helpful in your feedback.
+            Focus on significant issues only: bugs, security problems, or major quality concerns.
+            Skip minor style nitpicks. Follow CLAUDE.md conventions. Be concise.
 
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+            Post your review using `gh pr comment`.
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'


### PR DESCRIPTION
# Summary

- Remove automatic Claude review on every PR push to reduce noise and save resources
- Add four explicit trigger methods: manual dispatch, `/claude review` command, `auto-review` label, and draft-to-ready transitions
- Streamline review prompt to focus on significant issues only

## Motivation

The Claude Code Review workflow was triggering automatically on every PR push (`opened`, `synchronize`), creating noise, wasting CI resources and API credits, and interrupting iterative development. This change addresses issue #25 by making reviews opt-in through explicit actions.

## Implementation information

- Restructured `.github/workflows/claude-code-review.yml` with a two-job approach:
  - `check-trigger`: Evaluates trigger conditions and extracts PR number
  - `claude-review`: Runs only when `should_run == 'true'`
- Added four trigger types:
  - `workflow_dispatch` with PR number input for manual triggering
  - `issue_comment` for `/claude review` command detection
  - `pull_request[labeled]` for `auto-review` label
  - `pull_request[ready_for_review]` for draft-to-ready transitions
- Simplified review prompt to encourage concise, focused reviews on significant issues

## Test plan

- Validated with `actionlint` - no issues
- Validated embedded shell script with `shellcheck` - no issues
- Workflow logic uses case/switch pattern for clean trigger detection

## Supporting documentation

Closes #25
