### PR TITLE
fix(validator): use appropriate error codes for commit message validation

### DIFF
--- a/internal/validator/doc_links.go
+++ b/internal/validator/doc_links.go
@@ -21,6 +21,9 @@ var DefaultDocLinks = map[ErrorCode]string{
 	ErrGitPRRef:              BaseDocURL + "/GIT011.md",
 	ErrGitClaudeAttr:         BaseDocURL + "/GIT012.md",
 	ErrGitConventionalCommit: BaseDocURL + "/GIT013.md",
+	ErrGitForbiddenPattern:   BaseDocURL + "/GIT014.md",
+	ErrGitSignoffMismatch:    BaseDocURL + "/GIT015.md",
+	ErrGitListFormat:         BaseDocURL + "/GIT016.md",
 
 	// File documentation
 	ErrShellcheck:   BaseDocURL + "/FILE001.md",

--- a/internal/validator/error_code.go
+++ b/internal/validator/error_code.go
@@ -44,6 +44,15 @@ const (
 
 	// ErrGitConventionalCommit indicates invalid conventional commit format.
 	ErrGitConventionalCommit ErrorCode = "GIT013"
+
+	// ErrGitForbiddenPattern indicates forbidden pattern in commit message.
+	ErrGitForbiddenPattern ErrorCode = "GIT014"
+
+	// ErrGitSignoffMismatch indicates signoff identity mismatch.
+	ErrGitSignoffMismatch ErrorCode = "GIT015"
+
+	// ErrGitListFormat indicates list formatting issues in commit body.
+	ErrGitListFormat ErrorCode = "GIT016"
 )
 
 // File-related error codes (FILE001-FILE099).

--- a/internal/validator/suggestions.go
+++ b/internal/validator/suggestions.go
@@ -17,6 +17,9 @@ var DefaultSuggestions = map[ErrorCode]string{
 	ErrGitPRRef:              "Remove PR reference from commit message (use in PR body instead)",
 	ErrGitClaudeAttr:         "Remove Claude attribution from commit message",
 	ErrGitConventionalCommit: "Use conventional commit format: type(scope): description",
+	ErrGitForbiddenPattern:   "Remove forbidden pattern from commit message",
+	ErrGitSignoffMismatch:    "Use correct signoff identity: git config user.name and user.email",
+	ErrGitListFormat:         "Add empty line before list items in commit body",
 
 	// File suggestions
 	ErrShellcheck:   "Run 'shellcheck <file>' to see detailed errors",


### PR DESCRIPTION
# Summary

- Add differentiated error codes for commit message validation rules instead of using generic GIT013 for all failures
- Each validation rule now returns its specific error code, providing accurate fix suggestions
- Add three new error codes: GIT014 (forbidden patterns), GIT015 (signoff mismatch), GIT016 (list formatting)

## Motivation

When commit message validation fails due to title length or body formatting issues, users see error code `GIT013` with the misleading suggestion "Use conventional commit format: type(scope): description". This causes confusion because the actual issues (e.g., title exceeding 50 characters, missing blank line before list items) have nothing to do with conventional commit format compliance.

Closes #23

## Implementation information

- Created `RuleResult` struct in `commit_rules.go` containing both error messages and the specific error code
- Modified `CommitRule` interface to return `*RuleResult` instead of `[]string`
- Updated all validation rules to return their appropriate error codes:
  - `TitleLengthRule` → GIT004 (ErrGitBadTitle)
  - `ConventionalFormatRule` → GIT013 (ErrGitConventionalCommit)
  - `InfraScopeMisuseRule` → GIT006 (ErrGitFeatCI)
  - `BodyLineLengthRule` → GIT005 (ErrGitBadBody)
  - `ListFormattingRule` → GIT016 (ErrGitListFormat)
  - `PRReferenceRule` → GIT011 (ErrGitPRRef)
  - `AIAttributionRule` → GIT012 (ErrGitClaudeAttr)
  - `ForbiddenPatternRule` → GIT014 (ErrGitForbiddenPattern)
  - `SignoffRule` → GIT015 (ErrGitSignoffMismatch)
- Added `selectPrimaryErrorCode()` function with priority-based selection for cases with multiple validation failures
- Added suggestions and doc links for new error codes

## Test plan

- All 247 git validator tests pass
- All 64 validator package tests pass
- Verified build succeeds for internal packages

## Supporting documentation

- Issue: https://github.com/smykla-labs/klaudiush/issues/23
- New error codes documented in `internal/validator/error_code.go`
- Suggestions added in `internal/validator/suggestions.go`
- Doc links added in `internal/validator/doc_links.go`