### PR TITLE
fix(ci): address Copilot review suggestions for Claude review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -64,8 +64,9 @@ jobs:
               echo "Triggered via manual workflow dispatch for PR #$pr_number"
               ;;
             issue_comment)
-              # Check if comment is on a PR and contains "/claude review"
-              if [[ "$IS_PR_COMMENT" == "true" ]] && grep -qiE '/claude\s+review' <<< "$COMMENT_BODY"; then
+              # Check if comment is on a PR and contains "/claude review" command
+              # Pattern requires start-of-line or whitespace before command, word boundary after
+              if [[ "$IS_PR_COMMENT" == "true" ]] && grep -qiE '(^|\s)/claude\s+review\b' <<< "$COMMENT_BODY"; then
                 should_run="true"
                 pr_number="$ISSUE_NUMBER"
                 echo "Triggered via /claude review command on PR #$pr_number"


### PR DESCRIPTION
# Summary

- Address four code quality and security improvements from Copilot review of PR #27
- Improve shell script safety by using here-strings for untrusted input
- Add explicit permissions and simplify trigger condition logic

## Motivation

During the Copilot review of PR #27 (Claude review workflow configuration), four suggestions were identified to improve code quality and security. This PR implements all four recommendations to ensure the workflow is more robust, secure, and follows best practices.

## Implementation information

- **Regex pattern**: Changed from strict `^\s*/claude\s+review\s*$` to flexible `/claude\s+review` to match the command anywhere in comments (not just exact matches)
- **Security fix**: Replaced `echo "$COMMENT_BODY" | grep` with `grep <<< "$COMMENT_BODY"` here-string to safely handle untrusted user input without escape sequence issues
- **Redundant check removal**: Removed `$PR_DRAFT == "false"` condition since `ready_for_review` event only fires during draft-to-ready transitions by definition
- **Explicit permissions**: Added `pull-requests: read` and `issues: read` to `check-trigger` job instead of relying on inherited empty permissions
- **Cleanup**: Removed unused `PR_DRAFT` environment variable

## Supporting documentation

- Closes #28
- Related: #27 (original PR with Copilot review)
