### PR TITLE
ci(claude): fix review trigger false positives

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -65,8 +65,8 @@ jobs:
               ;;
             issue_comment)
               # Check if comment is on a PR and contains "/claude review" command
-              # Pattern requires start-of-line or whitespace before command, word boundary after
-              if [[ "$IS_PR_COMMENT" == "true" ]] && grep -qiE '(^|\s)/claude\s+review\b' <<< "$COMMENT_BODY"; then
+              # Pattern matches command at line boundaries to avoid false positives
+              if [[ "$IS_PR_COMMENT" == "true" ]] && grep -qiE '(^|\n)\s*/claude\s+review\s*($|\n)' <<< "$COMMENT_BODY"; then
                 should_run="true"
                 pr_number="$ISSUE_NUMBER"
                 echo "Triggered via /claude review command on PR #$pr_number"


### PR DESCRIPTION
## Summary

Address Copilot review feedback from PR 30 to fix regex pattern that could match `/claude review` command in the middle of sentences.

## Motivation

Copilot identified a security concern in the trigger pattern where `/claude review` could match in the middle of sentences (e.g., "I think /claude review is broken"), leading to false positive workflow triggers. The pattern should only match when the command appears at line boundaries in PR comments.

## Implementation information

- Changed regex from `(^|\s)/claude\s+review\b` to `(^|\n)\s*/claude\s+review\s*($|\n)`
- New pattern requires command at start/end of line, preventing mid-sentence matches
- Maintains support for multiline comments and case-insensitive matching

## Test Results

Tested with 13 test cases covering:

- Valid cases: command at start/end of lines, with spacing variations, case insensitive
- Invalid cases: command in middle of sentence, without proper spacing, with different suffix

All tests passed.

## Supporting documentation

Related to unresolved Copilot feedback: https://github.com/smykla-labs/klaudiush/pull/30#discussion_r2566598735

> Changelog: skip