### PR TITLE
ci(codecov): add token for protected branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
           fail_ci_if_error: false
         continue-on-error: true


### PR DESCRIPTION
## Motivation

Coverage uploads were failing on protected branches with error:

```json
{"message":"Token required because branch is protected"}
```

The CI workflow was attempting tokenless uploads, which are rejected for protected branches.

## Implementation information

- Added `token: ${{ secrets.CODECOV_TOKEN }}` parameter to `codecov-action` step in `.github/workflows/ci.yml`
- Configured `CODECOV_TOKEN` repository secret with Codecov upload token