### PR TITLE
fix(validators): align PR errors with policy

### DIFF
--- a/internal/validators/markdown_utils.go
+++ b/internal/validators/markdown_utils.go
@@ -732,10 +732,11 @@ func checkTables(content string, result *MarkdownAnalysisResult, widthMode mdtab
 		original := strings.Join(table.RawLines, "\n") + "\n"
 
 		if formatted != original {
-			result.Warnings = append(result.Warnings,
-				fmt.Sprintf("⚠️  Line %d: Markdown table has formatting issues", table.StartLine),
-				"   Table should be properly formatted with consistent column widths",
+			msg := fmt.Sprintf(
+				"Line %d: Markdown table has formatting issues (use consistent column widths)",
+				table.StartLine,
 			)
+			result.Warnings = append(result.Warnings, msg)
 			result.TableSuggested[table.StartLine] = formatted
 		}
 	}
@@ -743,7 +744,7 @@ func checkTables(content string, result *MarkdownAnalysisResult, widthMode mdtab
 	// Add any specific issues from parsing
 	for _, issue := range parseResult.Issues {
 		result.Warnings = append(result.Warnings,
-			fmt.Sprintf("⚠️  Line %d: %s", issue.Line, issue.Message),
+			fmt.Sprintf("Line %d: %s", issue.Line, issue.Message),
 		)
 	}
 }


### PR DESCRIPTION
## Summary

- Remove embedded emojis from markdown table warnings (dispatcher handles formatting based on `ShouldBlock`)
- Treat markdown formatting issues as warnings instead of blocking errors
- Use `strings.Builder` for cleaner message construction in `buildResult`
- Fix duplicate step numbers in `validatePR` comments

## Motivation

PR validation errors were not following the error format policy documented in `.claude/validator-error-format-policy.md`:

1. **Embedded emojis**: `markdown_utils.go` returned warnings with manually embedded `⚠️` emoji, but the dispatcher should handle this based on `ShouldBlock`
2. **Wrong categorization**: Markdown formatting issues were added to `allErrors` (blocking) instead of `allWarnings` (non-blocking)
3. **Manual formatting**: Multi-line warnings with manual `"   "` indent instead of letting dispatcher format

## Implementation information

- `internal/validators/markdown_utils.go`: Removed embedded `⚠️` emoji and manual indentation from `checkTables()` warnings
- `internal/validators/git/pr.go`: Changed markdown validation results from `allErrors` to `allWarnings`
- `internal/validators/git/pr.go`: Refactored `buildResult()` to use `strings.Builder`