### PR TITLE
fix(linters): disable MD013 for markdown fragments

### DIFF
--- a/internal/linters/markdownlint.go
+++ b/internal/linters/markdownlint.go
@@ -669,28 +669,36 @@ func (*RealMarkdownLinter) getConfigPattern(isMarkdownlintCli2 bool) string {
 }
 
 // GenerateFragmentConfigContent creates config content for fragment linting.
+// MD013 (line-length) is always disabled for fragments because context lines
+// around edits may legitimately exceed 80 characters.
 func GenerateFragmentConfigContent(isCli2, disableMD047 bool) string {
 	if isCli2 {
 		if disableMD047 {
 			return `{
   "config": {
+    "MD013": false,
     "MD047": false
   }
 }`
 		}
 
 		return `{
-  "config": {}
+  "config": {
+    "MD013": false
+  }
 }`
 	}
 
 	if disableMD047 {
 		return `{
+  "MD013": false,
   "MD047": false
 }`
 	}
 
-	return "{}"
+	return `{
+  "MD013": false
+}`
 }
 
 // GetFragmentConfigPattern returns the config file pattern for fragments.

--- a/internal/linters/markdownlint_test.go
+++ b/internal/linters/markdownlint_test.go
@@ -113,16 +113,22 @@ code
 			},
 			Entry("markdownlint-cli2 with MD047 disabled", true, true, `{
   "config": {
+    "MD013": false,
     "MD047": false
   }
 }`),
 			Entry("markdownlint-cli2 with MD047 enabled", true, false, `{
-  "config": {}
+  "config": {
+    "MD013": false
+  }
 }`),
 			Entry("markdownlint-cli with MD047 disabled", false, true, `{
+  "MD013": false,
   "MD047": false
 }`),
-			Entry("markdownlint-cli with MD047 enabled", false, false, "{}"),
+			Entry("markdownlint-cli with MD047 enabled", false, false, `{
+  "MD013": false
+}`),
 		)
 
 		DescribeTable("GetFragmentConfigPattern",
@@ -874,11 +880,14 @@ Summary: 1 error(s)
 						Return("/tmp/test.md", func() {}, nil)
 
 					// Fragment config for fragment that ends at EOF
+					// MD013 is always disabled for fragments (context lines may be long)
 					mockTempMgr.EXPECT().
 						Create("markdownlint-fragment-*.json", gomock.Any()).
 						DoAndReturn(func(_, content string) (string, func(), error) {
-							// Should be empty config (MD047 not disabled)
-							Expect(content).To(Equal("{}"))
+							// MD013 disabled, MD047 not disabled (ends at EOF)
+							Expect(content).To(Equal(`{
+  "MD013": false
+}`))
 
 							return "/tmp/fragment-config.json", func() {}, nil
 						})


### PR DESCRIPTION
## Motivation

When validating markdown file edits (Edit operations), the validator creates a fragment with context lines around the edit. The fragment config was only disabling MD047 (trailing newline), but not MD013 (line length). This caused false positives on context lines that exceed 80 characters - lines that the user didn't even edit.

## Implementation information

- Updated `GenerateFragmentConfigContent` to always include `"MD013": false` in fragment configs
- Added comment explaining why MD013 is disabled for fragments
- Updated all related tests to expect MD013 disabled in fragment configs