### PR TITLE
ci(lint): fix golangci-lint cache false positives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,6 @@ jobs:
         with:
           path: ~/.cache/golangci-lint
           key: golangci-lint-${{ runner.os }}-${{ hashFiles('**/*.go', '.golangci.yml', 'go.mod', 'go.sum') }}
-          restore-keys: |
-            golangci-lint-${{ runner.os }}-
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@e7fa5ac41e1cf5b7d48e45e42232ce7ada589601 # v9.1.0


### PR DESCRIPTION
## Motivation

Fix intermittent golangci-lint false positives caused by stale cache restoration in CI.

The `restore-keys` fallback pattern was restoring corrupted analysis facts when the exact cache key didn't match, causing false positives like SA5011 (nil pointer dereference after explicit nil check).

## Implementation information

- Remove `restore-keys` from golangci-lint cache configuration
- Cache is now restored only on **exact match** (all Go files, config, and dependencies identical)
- Any code change triggers a fresh lint run with no stale facts pollution