### PR TITLE
feat(git): validate remote exists for git fetch

### DIFF
--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -63,6 +63,7 @@ func DefaultGitConfig() *config.GitConfig {
 	return &config.GitConfig{
 		Commit:   DefaultCommitValidatorConfig(),
 		Push:     DefaultPushValidatorConfig(),
+		Fetch:    DefaultFetchValidatorConfig(),
 		Add:      DefaultAddValidatorConfig(),
 		PR:       DefaultPRValidatorConfig(),
 		Branch:   DefaultBranchValidatorConfig(),
@@ -182,6 +183,18 @@ func DefaultPushValidatorConfig() *config.PushValidatorConfig {
 		},
 		BlockedRemotes:  []string{},
 		RequireTracking: &requireTracking,
+	}
+}
+
+// DefaultFetchValidatorConfig returns the default fetch validator configuration.
+func DefaultFetchValidatorConfig() *config.FetchValidatorConfig {
+	enabled := true
+
+	return &config.FetchValidatorConfig{
+		ValidatorConfig: config.ValidatorConfig{
+			Enabled:  &enabled,
+			Severity: config.SeverityError,
+		},
 	}
 }
 

--- a/internal/config/koanf.go
+++ b/internal/config/koanf.go
@@ -474,6 +474,7 @@ func defaultGitValidatorsMap() map[string]any {
 	return map[string]any{
 		"commit":    defaultCommitMap(),
 		"push":      defaultPushMap(),
+		"fetch":     defaultFetchMap(),
 		"add":       defaultAddMap(),
 		"pr":        defaultPRMap(),
 		"branch":    defaultBranchMap(),
@@ -509,6 +510,13 @@ func defaultPushMap() map[string]any {
 		"severity":         "error",
 		"blocked_remotes":  []string{},
 		"require_tracking": true,
+	}
+}
+
+func defaultFetchMap() map[string]any {
+	return map[string]any{
+		"enabled":  true,
+		"severity": "error",
 	}
 }
 

--- a/internal/rules/types.go
+++ b/internal/rules/types.go
@@ -31,6 +31,7 @@ type ValidatorType string
 // Common validator type constants.
 const (
 	ValidatorGitPush       ValidatorType = "git.push"
+	ValidatorGitFetch      ValidatorType = "git.fetch"
 	ValidatorGitCommit     ValidatorType = "git.commit"
 	ValidatorGitAdd        ValidatorType = "git.add"
 	ValidatorGitPR         ValidatorType = "git.pr"

--- a/internal/validator/reference.go
+++ b/internal/validator/reference.go
@@ -79,6 +79,9 @@ const (
 
 	// RefGitPRValidation indicates PR validation failure (title, body, markdown, or labels).
 	RefGitPRValidation Reference = ReferenceBaseURL + "/GIT023"
+
+	// RefGitFetchNoRemote indicates remote does not exist for git fetch.
+	RefGitFetchNoRemote Reference = ReferenceBaseURL + "/GIT024"
 )
 
 // File-related references (FILE001-FILE005).

--- a/internal/validator/suggestions.go
+++ b/internal/validator/suggestions.go
@@ -27,6 +27,7 @@ var DefaultSuggestions = map[Reference]string{
 	RefGitNoVerify:           "Remove --no-verify flag and fix any pre-commit hook issues",
 	RefGitKongOrgPush:        "Push to 'upstream' remote instead: git push upstream <branch>",
 	RefGitPRValidation:       "Fix PR title, body, markdown formatting, or labels per validation errors",
+	RefGitFetchNoRemote:      "Specify valid remote: git fetch <remote> (use 'git remote -v' to list remotes)",
 
 	// File suggestions
 	RefShellcheck:   "Run 'shellcheck <file>' to see detailed errors",

--- a/internal/validators/git/fetch.go
+++ b/internal/validators/git/fetch.go
@@ -1,0 +1,127 @@
+package git
+
+import (
+	"context"
+	"strings"
+
+	"github.com/smykla-labs/klaudiush/internal/rules"
+	"github.com/smykla-labs/klaudiush/internal/validator"
+	"github.com/smykla-labs/klaudiush/pkg/config"
+	"github.com/smykla-labs/klaudiush/pkg/hook"
+	"github.com/smykla-labs/klaudiush/pkg/logger"
+	"github.com/smykla-labs/klaudiush/pkg/parser"
+)
+
+// FetchValidator validates git fetch commands to ensure the remote exists.
+type FetchValidator struct {
+	validator.BaseValidator
+	gitRunner    GitRunner
+	config       *config.FetchValidatorConfig
+	ruleAdapter  *rules.RuleValidatorAdapter
+	remoteHelper *RemoteHelper
+}
+
+// NewFetchValidator creates a new FetchValidator instance.
+func NewFetchValidator(
+	log logger.Logger,
+	gitRunner GitRunner,
+	cfg *config.FetchValidatorConfig,
+	ruleAdapter *rules.RuleValidatorAdapter,
+) *FetchValidator {
+	if gitRunner == nil {
+		gitRunner = NewGitRunner()
+	}
+
+	return &FetchValidator{
+		BaseValidator: *validator.NewBaseValidator("validate-git-fetch", log),
+		gitRunner:     gitRunner,
+		config:        cfg,
+		ruleAdapter:   ruleAdapter,
+		remoteHelper:  NewRemoteHelper(),
+	}
+}
+
+// Name returns the validator name.
+func (*FetchValidator) Name() string {
+	return "validate-git-fetch"
+}
+
+// Validate validates git fetch commands.
+func (v *FetchValidator) Validate(ctx context.Context, hookCtx *hook.Context) *validator.Result {
+	return ValidateGitSubcommand(
+		ctx,
+		hookCtx,
+		v.ruleAdapter,
+		v.Logger(),
+		"fetch",
+		v.validateFetchCommand,
+	)
+}
+
+// validateFetchCommand validates a single git fetch command.
+func (v *FetchValidator) validateFetchCommand(gitCmd *parser.GitCommand) *validator.Result {
+	log := v.Logger()
+
+	// Use path-specific runner if -C flag is present
+	runner := v.getRunnerForCommand(gitCmd)
+
+	if !runner.IsInRepo() {
+		log.Debug("not in a git repository, skipping validation")
+
+		return validator.Pass()
+	}
+
+	remote := v.extractRemote(gitCmd)
+	if remote == "" {
+		log.Debug("no remote specified, skipping validation")
+
+		return validator.Pass()
+	}
+
+	return v.remoteHelper.ValidateRemoteExists(
+		remote,
+		runner,
+		validator.RefGitFetchNoRemote,
+		"🚫 Git fetch validation failed:",
+	)
+}
+
+// getRunnerForCommand returns the appropriate git runner for the command.
+// If the command specifies a working directory with -C, creates a runner for that path.
+// Otherwise, returns the default cached runner.
+//
+//nolint:ireturn // Returns interface for flexibility between cached and path-specific runners
+func (v *FetchValidator) getRunnerForCommand(gitCmd *parser.GitCommand) GitRunner {
+	workDir := gitCmd.GetWorkingDirectory()
+	if workDir != "" {
+		v.Logger().Debug("using path-specific runner", "path", workDir)
+
+		return NewGitRunnerForPath(workDir)
+	}
+
+	return v.gitRunner
+}
+
+// extractRemote extracts the remote name from a git fetch command.
+// Handles: git fetch <remote>, git fetch --prune <remote>, git fetch -p <remote>
+func (*FetchValidator) extractRemote(gitCmd *parser.GitCommand) string {
+	if len(gitCmd.Args) == 0 {
+		// git fetch with no args fetches from configured upstream or origin
+		return ""
+	}
+
+	// Find the first non-flag argument (the remote name)
+	for _, arg := range gitCmd.Args {
+		if !strings.HasPrefix(arg, "-") {
+			return arg
+		}
+	}
+
+	return ""
+}
+
+// Category returns the validator category for parallel execution.
+// FetchValidator uses CategoryGit because it queries git remote state.
+func (*FetchValidator) Category() validator.ValidatorCategory {
+	return validator.CategoryGit
+}

--- a/internal/validators/git/fetch_test.go
+++ b/internal/validators/git/fetch_test.go
@@ -1,0 +1,215 @@
+package git_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	gitpkg "github.com/smykla-labs/klaudiush/internal/git"
+	validatorpkg "github.com/smykla-labs/klaudiush/internal/validator"
+	"github.com/smykla-labs/klaudiush/internal/validators/git"
+	"github.com/smykla-labs/klaudiush/pkg/hook"
+	"github.com/smykla-labs/klaudiush/pkg/logger"
+)
+
+var _ = Describe("FetchValidator", func() {
+	var (
+		validator *git.FetchValidator
+		fakeGit   *gitpkg.FakeRunner
+		log       logger.Logger
+	)
+
+	BeforeEach(func() {
+		log = logger.NewNoOpLogger()
+		fakeGit = gitpkg.NewFakeRunner()
+		fakeGit.InRepo = true
+		fakeGit.RepoRoot = "/home/user/projects/github.com/user/my-project"
+		validator = git.NewFetchValidator(log, fakeGit, nil, nil)
+	})
+
+	// Helper function to create context with command
+	createContext := func(command string) *hook.Context {
+		return &hook.Context{
+			EventType: hook.EventTypePreToolUse,
+			ToolName:  hook.ToolTypeBash,
+			ToolInput: hook.ToolInput{
+				Command: command,
+			},
+		}
+	}
+
+	Describe("Name", func() {
+		It("returns the validator name", func() {
+			Expect(validator.Name()).To(Equal("validate-git-fetch"))
+		})
+	})
+
+	Describe("Category", func() {
+		It("returns CategoryGit", func() {
+			Expect(validator.Category()).To(Equal(validatorpkg.CategoryGit))
+		})
+	})
+
+	Describe("Validate", func() {
+		Context("when not a git command", func() {
+			It("passes for non-git command", func() {
+				ctx := createContext("ls -la")
+				result := validator.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeTrue())
+			})
+		})
+
+		Context("when not in a git repository", func() {
+			It("passes when not in repo", func() {
+				fakeGit.InRepo = false
+				ctx := createContext("git fetch upstream")
+				result := validator.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeTrue())
+			})
+		})
+
+		Context("remote existence validation", func() {
+			It("passes when remote exists", func() {
+				ctx := createContext("git fetch origin")
+				result := validator.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeTrue())
+			})
+
+			It("passes when fetching upstream remote", func() {
+				ctx := createContext("git fetch upstream")
+				result := validator.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeTrue())
+			})
+
+			It("fails when remote does not exist", func() {
+				ctx := createContext("git fetch nonexistent")
+				result := validator.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeFalse())
+				Expect(result.Message).To(ContainSubstring("Git fetch validation failed"))
+				Expect(result.Message).To(ContainSubstring("Remote 'nonexistent' does not exist"))
+				Expect(result.Message).To(ContainSubstring("Available remotes:"))
+				Expect(result.Message).To(ContainSubstring("origin"))
+				Expect(result.Message).To(ContainSubstring("upstream"))
+			})
+
+			It("extracts remote from various fetch formats", func() {
+				testCases := []struct {
+					command     string
+					shouldPass  bool
+					description string
+				}{
+					{
+						command:     "git fetch origin",
+						shouldPass:  true,
+						description: "explicit remote",
+					},
+					{
+						command:     "git fetch upstream",
+						shouldPass:  true,
+						description: "upstream remote",
+					},
+					{
+						command:     "git fetch --prune origin",
+						shouldPass:  true,
+						description: "with --prune flag",
+					},
+					{
+						command:     "git fetch -p origin",
+						shouldPass:  true,
+						description: "with -p flag",
+					},
+					{
+						command:     "git fetch --prune badremote",
+						shouldPass:  false,
+						description: "prune with nonexistent remote",
+					},
+					{
+						command:     "git fetch -p badremote",
+						shouldPass:  false,
+						description: "-p with nonexistent remote",
+					},
+					{
+						command:     "git fetch --all",
+						shouldPass:  true,
+						description: "fetch all (no remote specified)",
+					},
+					{
+						command:     "git fetch",
+						shouldPass:  true,
+						description: "no remote specified (uses default)",
+					},
+				}
+
+				for _, tc := range testCases {
+					ctx := createContext(tc.command)
+					result := validator.Validate(context.Background(), ctx)
+					Expect(result.Passed).To(Equal(tc.shouldPass), tc.description)
+				}
+			})
+		})
+
+		Context("edge cases", func() {
+			It("passes for empty command", func() {
+				ctx := createContext("")
+				result := validator.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeTrue())
+			})
+
+			It("passes for git commands other than fetch", func() {
+				ctx := createContext("git pull upstream main")
+				result := validator.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeTrue())
+			})
+
+			It("passes when command has syntax that parser cannot handle", func() {
+				ctx := createContext("git fetch $((")
+				result := validator.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeTrue())
+			})
+
+			It("handles missing remote gracefully", func() {
+				fakeGit.Remotes = map[string]string{}
+				ctx := createContext("git fetch origin")
+				result := validator.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeFalse())
+			})
+		})
+
+		Context("with -C flag for different directory", func() {
+			It("passes for git fetch with -C flag to valid repo", func() {
+				ctx := createContext("git -C /path/to/worktree fetch origin")
+				result := validator.Validate(context.Background(), ctx)
+				// This creates a new runner for the path, which won't find the repo
+				// but should handle gracefully
+				Expect(result.Passed).To(BeTrue())
+			})
+
+			It("handles -C flag before fetch subcommand", func() {
+				ctx := createContext("git -C /some/path fetch upstream")
+				result := validator.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeTrue())
+			})
+		})
+
+		Context("combined flags", func() {
+			It("handles multiple flags before remote", func() {
+				ctx := createContext("git fetch --prune --tags origin")
+				result := validator.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeTrue())
+			})
+
+			It("handles verbose flag", func() {
+				ctx := createContext("git fetch -v origin")
+				result := validator.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeTrue())
+			})
+
+			It("handles dry-run flag", func() {
+				ctx := createContext("git fetch --dry-run origin")
+				result := validator.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeTrue())
+			})
+		})
+	})
+})

--- a/internal/validators/git/push.go
+++ b/internal/validators/git/push.go
@@ -2,11 +2,9 @@ package git
 
 import (
 	"context"
-	"sort"
 	"strings"
 
 	"github.com/smykla-labs/klaudiush/internal/rules"
-	"github.com/smykla-labs/klaudiush/internal/templates"
 	"github.com/smykla-labs/klaudiush/internal/validator"
 	"github.com/smykla-labs/klaudiush/pkg/config"
 	"github.com/smykla-labs/klaudiush/pkg/hook"
@@ -52,50 +50,14 @@ func (*PushValidator) Name() string {
 
 // Validate validates git push commands
 func (v *PushValidator) Validate(ctx context.Context, hookCtx *hook.Context) *validator.Result {
-	log := v.Logger()
-
-	// Check rules first if rule adapter is configured
-	if v.ruleAdapter != nil {
-		if result := v.ruleAdapter.CheckRules(ctx, hookCtx); result != nil {
-			return result
-		}
-	}
-
-	command := hookCtx.GetCommand()
-	if command == "" {
-		return validator.Pass()
-	}
-
-	bashParser := parser.NewBashParser()
-
-	parseResult, err := bashParser.Parse(command)
-	if err != nil {
-		log.Debug("failed to parse command", "error", err)
-		return validator.Pass()
-	}
-
-	for _, cmd := range parseResult.Commands {
-		if cmd.Name != "git" || len(cmd.Args) == 0 {
-			continue
-		}
-
-		gitCmd, parseErr := parser.ParseGitCommand(cmd)
-		if parseErr != nil {
-			log.Debug("failed to parse git command", "error", parseErr)
-			continue
-		}
-
-		if gitCmd.Subcommand != "push" {
-			continue
-		}
-
-		result := v.validatePushCommand(gitCmd)
-		if !result.Passed {
-			return result
-		}
-	}
-
-	return validator.Pass()
+	return ValidateGitSubcommand(
+		ctx,
+		hookCtx,
+		v.ruleAdapter,
+		v.Logger(),
+		"push",
+		v.validatePushCommand,
+	)
 }
 
 // validatePushCommand validates a single git push command
@@ -160,49 +122,14 @@ func (*PushValidator) extractRemote(gitCmd *parser.GitCommand, runner GitRunner)
 }
 
 // validateRemoteExists checks if the remote exists
-func (v *PushValidator) validateRemoteExists(remote string, runner GitRunner) *validator.Result {
-	_, err := runner.GetRemoteURL(remote)
-	if err != nil {
-		remotes, remoteErr := runner.GetRemotes()
-		if remoteErr != nil {
-			return validator.FailWithRef(
-				validator.RefGitNoRemote,
-				"🚫 Git push validation failed:\n\n❌ Remote '"+remote+"' does not exist",
-			)
-		}
+func (*PushValidator) validateRemoteExists(remote string, runner GitRunner) *validator.Result {
+	helper := NewRemoteHelper()
 
-		return validator.FailWithRef(
-			validator.RefGitNoRemote,
-			"🚫 Git push validation failed:\n\n"+v.formatRemoteNotFoundError(remote, remotes),
-		)
-	}
-
-	return validator.Pass()
-}
-
-// formatRemoteNotFoundError formats the error message for a missing remote
-func (*PushValidator) formatRemoteNotFoundError(remote string, remotes map[string]string) string {
-	names := make([]string, 0, len(remotes))
-	for name := range remotes {
-		names = append(names, name)
-	}
-
-	sort.Strings(names)
-
-	remoteInfos := make([]templates.RemoteInfo, len(names))
-	for i, name := range names {
-		remoteInfos[i] = templates.RemoteInfo{
-			Name: name,
-			URL:  remotes[name],
-		}
-	}
-
-	return templates.MustExecute(
-		templates.PushRemoteNotFoundTemplate,
-		templates.PushRemoteNotFoundData{
-			Remote:  remote,
-			Remotes: remoteInfos,
-		},
+	return helper.ValidateRemoteExists(
+		remote,
+		runner,
+		validator.RefGitNoRemote,
+		"🚫 Git push validation failed:",
 	)
 }
 

--- a/internal/validators/git/remote_helper.go
+++ b/internal/validators/git/remote_helper.go
@@ -1,0 +1,138 @@
+package git
+
+import (
+	"context"
+	"sort"
+
+	"github.com/smykla-labs/klaudiush/internal/rules"
+	"github.com/smykla-labs/klaudiush/internal/templates"
+	"github.com/smykla-labs/klaudiush/internal/validator"
+	"github.com/smykla-labs/klaudiush/pkg/hook"
+	"github.com/smykla-labs/klaudiush/pkg/logger"
+	"github.com/smykla-labs/klaudiush/pkg/parser"
+)
+
+const (
+	// gitCmdName is the name of the git command.
+	gitCmdName = "git"
+)
+
+// GitCommandValidatorFunc is a function that validates a parsed git command.
+type GitCommandValidatorFunc func(gitCmd *parser.GitCommand) *validator.Result
+
+// RemoteHelper provides shared remote validation logic for git validators.
+type RemoteHelper struct{}
+
+// NewRemoteHelper creates a new RemoteHelper.
+func NewRemoteHelper() *RemoteHelper {
+	return &RemoteHelper{}
+}
+
+// ValidateRemoteExists checks if the remote exists and returns a validation result.
+// Returns Pass() if remote exists, Fail() with available remotes list if not.
+func (*RemoteHelper) ValidateRemoteExists(
+	remote string,
+	runner GitRunner,
+	ref validator.Reference,
+	headerMsg string,
+) *validator.Result {
+	_, err := runner.GetRemoteURL(remote)
+	if err != nil {
+		remotes, remoteErr := runner.GetRemotes()
+		if remoteErr != nil {
+			return validator.FailWithRef(
+				ref,
+				headerMsg+"\n\n❌ Remote '"+remote+"' does not exist",
+			)
+		}
+
+		return validator.FailWithRef(
+			ref,
+			headerMsg+"\n\n"+FormatRemoteNotFoundError(remote, remotes),
+		)
+	}
+
+	return validator.Pass()
+}
+
+// FormatRemoteNotFoundError formats the error message for a missing remote.
+func FormatRemoteNotFoundError(remote string, remotes map[string]string) string {
+	names := make([]string, 0, len(remotes))
+	for name := range remotes {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	remoteInfos := make([]templates.RemoteInfo, len(names))
+	for i, name := range names {
+		remoteInfos[i] = templates.RemoteInfo{
+			Name: name,
+			URL:  remotes[name],
+		}
+	}
+
+	return templates.MustExecute(
+		templates.PushRemoteNotFoundTemplate,
+		templates.PushRemoteNotFoundData{
+			Remote:  remote,
+			Remotes: remoteInfos,
+		},
+	)
+}
+
+// ValidateGitSubcommand provides common validation loop for git subcommand validators.
+// It handles rule checking, command parsing, and subcommand filtering.
+func ValidateGitSubcommand(
+	ctx context.Context,
+	hookCtx *hook.Context,
+	ruleAdapter *rules.RuleValidatorAdapter,
+	log logger.Logger,
+	subcommand string,
+	validateCmd GitCommandValidatorFunc,
+) *validator.Result {
+	// Check rules first if rule adapter is configured
+	if ruleAdapter != nil {
+		if result := ruleAdapter.CheckRules(ctx, hookCtx); result != nil {
+			return result
+		}
+	}
+
+	command := hookCtx.GetCommand()
+	if command == "" {
+		return validator.Pass()
+	}
+
+	bashParser := parser.NewBashParser()
+
+	parseResult, err := bashParser.Parse(command)
+	if err != nil {
+		log.Debug("failed to parse command", "error", err)
+
+		return validator.Pass()
+	}
+
+	for _, cmd := range parseResult.Commands {
+		if cmd.Name != gitCmdName || len(cmd.Args) == 0 {
+			continue
+		}
+
+		gitCmd, parseErr := parser.ParseGitCommand(cmd)
+		if parseErr != nil {
+			log.Debug("failed to parse git command", "error", parseErr)
+
+			continue
+		}
+
+		if gitCmd.Subcommand != subcommand {
+			continue
+		}
+
+		result := validateCmd(gitCmd)
+		if !result.Passed {
+			return result
+		}
+	}
+
+	return validator.Pass()
+}

--- a/pkg/config/git.go
+++ b/pkg/config/git.go
@@ -9,6 +9,9 @@ type GitConfig struct {
 	// Push validator configuration
 	Push *PushValidatorConfig `json:"push,omitempty" koanf:"push" toml:"push"`
 
+	// Fetch validator configuration
+	Fetch *FetchValidatorConfig `json:"fetch,omitempty" koanf:"fetch" toml:"fetch"`
+
 	// Add validator configuration
 	Add *AddValidatorConfig `json:"add,omitempty" koanf:"add" toml:"add"`
 
@@ -273,4 +276,12 @@ type NoVerifyValidatorConfig struct {
 
 	// No additional configuration beyond base ValidatorConfig
 	// This validator blocks --no-verify flag on git commit commands
+}
+
+// FetchValidatorConfig configures the git fetch validator.
+type FetchValidatorConfig struct {
+	ValidatorConfig
+
+	// No additional configuration beyond base ValidatorConfig
+	// This validator checks that the remote exists before fetch
 }


### PR DESCRIPTION
## Motivation

When Claude attempts to fetch from a non-existent remote, the git command fails with an unhelpful error. This validator catches the error early with a helpful message listing available remotes.

## Implementation information

- Add `FetchValidator` to validate that the remote exists before allowing `git fetch` commands
- Extract shared `ValidateGitSubcommand()` helper to reduce code duplication between push and fetch validators (~89 lines removed from push.go)
- Reuse existing `FormatRemoteNotFoundError()` for consistent error formatting
- Add `GIT024` error code with fix suggestion

Closes #78