### PR TITLE
fix(shellscript): handle fragment edits correctly

### DIFF
--- a/internal/linters/shellcheck_mock.go
+++ b/internal/linters/shellcheck_mock.go
@@ -53,3 +53,17 @@ func (mr *MockShellCheckerMockRecorder) Check(ctx, content any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Check", reflect.TypeOf((*MockShellChecker)(nil).Check), ctx, content)
 }
+
+// CheckWithOptions mocks base method.
+func (m *MockShellChecker) CheckWithOptions(ctx context.Context, content string, opts *ShellCheckOptions) *LintResult {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckWithOptions", ctx, content, opts)
+	ret0, _ := ret[0].(*LintResult)
+	return ret0
+}
+
+// CheckWithOptions indicates an expected call of CheckWithOptions.
+func (mr *MockShellCheckerMockRecorder) CheckWithOptions(ctx, content, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckWithOptions", reflect.TypeOf((*MockShellChecker)(nil).CheckWithOptions), ctx, content, opts)
+}

--- a/internal/validators/file/shellscript.go
+++ b/internal/validators/file/shellscript.go
@@ -45,6 +45,12 @@ func NewShellScriptValidator(
 	}
 }
 
+// fragmentExcludes are shellcheck codes to exclude when validating fragments.
+// These are false positives due to limited context:
+// - SC2034: variable appears unused (may be used elsewhere in the file)
+// - SC2154: variable is referenced but not assigned (may be assigned elsewhere)
+var fragmentExcludes = []int{2034, 2154}
+
 // Validate validates shell scripts using shellcheck.
 func (v *ShellScriptValidator) Validate(
 	ctx context.Context,
@@ -68,14 +74,14 @@ func (v *ShellScriptValidator) Validate(
 	}
 
 	// Get content based on operation type
-	content, err := v.getContent(hookCtx, filePath)
+	sc, err := v.getContent(hookCtx, filePath)
 	if err != nil {
 		log.Debug("failed to get content", "error", err)
 		return validator.Pass()
 	}
 
 	// Skip Fish scripts
-	if v.isFishScript(filePath, content) {
+	if v.isFishScript(filePath, sc.content) {
 		log.Debug("skipping Fish script", "file", filePath)
 		return validator.Pass()
 	}
@@ -84,7 +90,16 @@ func (v *ShellScriptValidator) Validate(
 	lintCtx, cancel := context.WithTimeout(ctx, v.getTimeout())
 	defer cancel()
 
-	result := v.checker.Check(lintCtx, content)
+	// Use fragment-specific options to exclude false positives
+	var result *linters.LintResult
+
+	if sc.isFragment {
+		opts := &linters.ShellCheckOptions{ExcludeCodes: fragmentExcludes}
+		result = v.checker.CheckWithOptions(lintCtx, sc.content, opts)
+	} else {
+		result = v.checker.Check(lintCtx, sc.content)
+	}
+
 	if result.Success {
 		log.Debug("shellcheck passed")
 		return validator.Pass()
@@ -95,35 +110,49 @@ func (v *ShellScriptValidator) Validate(
 	return validator.FailWithRef(validator.RefShellcheck, v.formatShellCheckOutput(result.RawOut))
 }
 
+// shellContent holds shell script content and metadata for validation
+type shellContent struct {
+	content    string
+	isFragment bool
+}
+
 // getContent extracts shell script content from context
-func (v *ShellScriptValidator) getContent(ctx *hook.Context, filePath string) (string, error) {
+func (v *ShellScriptValidator) getContent(
+	ctx *hook.Context,
+	filePath string,
+) (*shellContent, error) {
 	log := v.Logger()
 
 	// For Edit operations, validate only the changed fragment with context
 	if ctx.EventType == hook.EventTypePreToolUse && ctx.ToolName == hook.ToolTypeEdit {
-		return v.getEditContent(ctx, filePath)
+		content, err := v.getEditContent(ctx, filePath)
+		if err != nil {
+			return nil, err
+		}
+
+		return &shellContent{content: content, isFragment: true}, nil
 	}
 
 	// Get content from context or read from file (Write operation)
 	content := ctx.ToolInput.Content
 	if content != "" {
-		return content, nil
+		return &shellContent{content: content, isFragment: false}, nil
 	}
 
 	// Check if file exists
 	if _, err := os.Stat(filePath); err != nil {
 		log.Debug("file does not exist, skipping", "file", filePath)
-		return "", err
+		return nil, err
 	}
 
 	// Read file content
 	data, err := os.ReadFile(filePath) //nolint:gosec // filePath is from Claude Code context
 	if err != nil {
 		log.Debug("failed to read file", "file", filePath, "error", err)
-		return "", err
+		return nil, err
 	}
 
-	return string(data), nil
+	return &shellContent{content: string(data), isFragment: false}, nil
 }
 
 // getEditContent extracts content for Edit operations with context
@@ -149,9 +178,11 @@ func (v *ShellScriptValidator) getEditContent(
 		return "", err
 	}
 
+	originalStr := string(originalContent)
+
 	// Extract fragment with context lines around the edit
 	fragment := ExtractEditFragment(
-		string(originalContent),
+		originalStr,
 		oldStr,
 		newStr,
 		v.getContextLines(),
@@ -162,10 +193,78 @@ func (v *ShellScriptValidator) getEditContent(
 		return "", os.ErrNotExist
 	}
 
+	// Calculate fragment start line to determine if shebang needs to be prepended
+	fragmentStartLine := getFragmentStartLine(originalStr, oldStr, v.getContextLines())
+
+	// If fragment doesn't start at line 0, prepend shebang or shell directive
+	// to avoid SC2148 (unknown shell) errors
+	if fragmentStartLine > 0 {
+		fragment = v.prependShellDirective(originalStr, fragment, log)
+	}
+
 	fragmentLineCount := len(strings.Split(fragment, "\n"))
-	log.Debug("validating edit fragment with context", "fragment_lines", fragmentLineCount)
+	log.Debug("validating edit fragment with context",
+		"fragment_lines", fragmentLineCount,
+		"fragment_start_line", fragmentStartLine,
+	)
 
 	return fragment, nil
+}
+
+// prependShellDirective prepends a shellcheck shell directive to the fragment
+// based on the shebang from the original file. This ensures shellcheck knows
+// which shell to use when validating fragments that don't include line 1.
+func (*ShellScriptValidator) prependShellDirective(
+	originalContent string,
+	fragment string,
+	log logger.Logger,
+) string {
+	shell := detectShellFromShebang(originalContent)
+	if shell == "" {
+		log.Debug("no shell detected from shebang, fragment may fail validation")
+		return fragment
+	}
+
+	// Use shellcheck directive instead of shebang to avoid confusing line numbers
+	// https://www.shellcheck.net/wiki/Directive
+	directive := "# shellcheck shell=" + shell + "\n"
+	log.Debug("prepending shell directive for fragment", "shell", shell)
+
+	return directive + fragment
+}
+
+// detectShellFromShebang extracts the shell name from a shebang line.
+// Returns empty string if no shebang is found or shell cannot be determined.
+func detectShellFromShebang(content string) string {
+	if !strings.HasPrefix(content, "#!") {
+		return ""
+	}
+
+	// Get first line
+	firstLine := content
+	if idx := strings.Index(content, "\n"); idx != -1 {
+		firstLine = content[:idx]
+	}
+
+	// Common shebang patterns
+	switch {
+	case strings.Contains(firstLine, "/bash"):
+		return "bash"
+	case strings.Contains(firstLine, "/sh"):
+		return "sh"
+	case strings.Contains(firstLine, "/zsh"):
+		return "zsh"
+	case strings.Contains(firstLine, "/ksh"):
+		return "ksh"
+	case strings.Contains(firstLine, "/dash"):
+		return "dash"
+	case strings.HasSuffix(firstLine, "bash"):
+		return "bash"
+	case strings.HasSuffix(firstLine, "sh"):
+		return "sh"
+	}
+
+	return ""
 }
 
 // isFishScript checks if the script is a Fish shell script.


### PR DESCRIPTION
## Summary

This PR fixes fragment validation for shell scripts by:

- Prepending a `# shellcheck shell=<shell>` directive based on the original file's shebang
- Excluding context-dependent shellcheck codes (SC2034, SC2154) for fragment edits

## Motivation

When using the Claude Code Edit tool to modify shell scripts, the validator would fail with false positives because the fragment being edited doesn't have full file context. Specifically:

- SC2148 (unknown shell) error because the fragment doesn't include the shebang
- SC2034 (unused variable) warnings for variables defined in the fragment but used elsewhere in the file

## Implementation information

- Add `ShellCheckOptions` struct and `CheckWithOptions` method to `ShellChecker` interface
- Add `detectShellFromShebang` helper to extract shell type from shebang patterns
- Add `prependShellDirective` to prepend shell directive for fragments not starting at line 0
- Return `shellContent` struct from `getContent` to track whether content is a fragment