### PR TITLE
fix(shellscript): apply config exclude_rules

### DIFF
--- a/internal/validators/file/shellscript_test.go
+++ b/internal/validators/file/shellscript_test.go
@@ -12,6 +12,7 @@ import (
 	execpkg "github.com/smykla-labs/klaudiush/internal/exec"
 	"github.com/smykla-labs/klaudiush/internal/linters"
 	"github.com/smykla-labs/klaudiush/internal/validators/file"
+	"github.com/smykla-labs/klaudiush/pkg/config"
 	"github.com/smykla-labs/klaudiush/pkg/hook"
 	"github.com/smykla-labs/klaudiush/pkg/logger"
 )
@@ -263,6 +264,132 @@ process_data "test"
 			ctx.ToolInput.NewString = `local -r data="$1"`
 
 			result := v.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeTrue())
+		})
+	})
+
+	Describe("config exclude rules", func() {
+		It("should exclude rules specified in config", func() {
+			// SC2086: Double quote to prevent globbing and word splitting
+			// This script would fail without the exclusion
+			runner := execpkg.NewCommandRunner(10 * time.Second)
+			checker := linters.NewShellChecker(runner)
+			cfg := &config.ShellScriptValidatorConfig{
+				ExcludeRules: []string{"SC2086"},
+			}
+			validator := file.NewShellScriptValidator(logger.NewNoOpLogger(), checker, cfg, nil)
+
+			hookCtx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeWrite,
+				ToolInput: hook.ToolInput{
+					FilePath: "test.sh",
+					Content: `#!/bin/bash
+VAR="hello world"
+echo $VAR
+`,
+				},
+			}
+
+			result := validator.Validate(context.Background(), hookCtx)
+			Expect(result.Passed).To(BeTrue())
+		})
+
+		It("should exclude rules with SC prefix", func() {
+			runner := execpkg.NewCommandRunner(10 * time.Second)
+			checker := linters.NewShellChecker(runner)
+			cfg := &config.ShellScriptValidatorConfig{
+				ExcludeRules: []string{"SC2086", "SC2154"},
+			}
+			validator := file.NewShellScriptValidator(logger.NewNoOpLogger(), checker, cfg, nil)
+
+			hookCtx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeWrite,
+				ToolInput: hook.ToolInput{
+					FilePath: "test.sh",
+					Content: `#!/bin/bash
+echo $UNDEFINED_VAR
+echo $ANOTHER_VAR
+`,
+				},
+			}
+
+			result := validator.Validate(context.Background(), hookCtx)
+			Expect(result.Passed).To(BeTrue())
+		})
+
+		It("should exclude rules without SC prefix", func() {
+			runner := execpkg.NewCommandRunner(10 * time.Second)
+			checker := linters.NewShellChecker(runner)
+			cfg := &config.ShellScriptValidatorConfig{
+				ExcludeRules: []string{"2086"},
+			}
+			validator := file.NewShellScriptValidator(logger.NewNoOpLogger(), checker, cfg, nil)
+
+			hookCtx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeWrite,
+				ToolInput: hook.ToolInput{
+					FilePath: "test.sh",
+					Content: `#!/bin/bash
+VAR="hello world"
+echo $VAR
+`,
+				},
+			}
+
+			result := validator.Validate(context.Background(), hookCtx)
+			Expect(result.Passed).To(BeTrue())
+		})
+
+		It("should still fail for non-excluded rules", func() {
+			runner := execpkg.NewCommandRunner(10 * time.Second)
+			checker := linters.NewShellChecker(runner)
+			cfg := &config.ShellScriptValidatorConfig{
+				ExcludeRules: []string{"SC2086"}, // Only exclude 2086
+			}
+			validator := file.NewShellScriptValidator(logger.NewNoOpLogger(), checker, cfg, nil)
+
+			hookCtx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeWrite,
+				ToolInput: hook.ToolInput{
+					FilePath: "test.sh",
+					Content: `#!/bin/bash
+if [ -f file.txt ]
+  echo "File exists"
+fi
+`,
+				},
+			}
+
+			result := validator.Validate(context.Background(), hookCtx)
+			Expect(result.Passed).To(BeFalse())
+		})
+
+		It("should ignore invalid rule codes", func() {
+			runner := execpkg.NewCommandRunner(10 * time.Second)
+			checker := linters.NewShellChecker(runner)
+			cfg := &config.ShellScriptValidatorConfig{
+				ExcludeRules: []string{"invalid", "SC2086", "notanumber"},
+			}
+			validator := file.NewShellScriptValidator(logger.NewNoOpLogger(), checker, cfg, nil)
+
+			hookCtx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeWrite,
+				ToolInput: hook.ToolInput{
+					FilePath: "test.sh",
+					Content: `#!/bin/bash
+VAR="hello world"
+echo $VAR
+`,
+				},
+			}
+
+			// Should still work with valid rule (SC2086)
+			result := validator.Validate(context.Background(), hookCtx)
 			Expect(result.Passed).To(BeTrue())
 		})
 	})


### PR DESCRIPTION
## Summary

Fix `ShellScriptValidatorConfig.ExcludeRules` being ignored by the shellcheck validator.

## Motivation

The `exclude_rules` config option was defined in `pkg/config/file.go` but never used by the `ShellScriptValidator`. Users configuring `.klaudiush/config.toml` with `exclude_rules = ["SC1091", "SC2034"]` expected those rules to be excluded, but they were not.

## Implementation information

- Add `buildShellCheckOptions()` to merge config excludes with fragment-specific excludes
- Add `parseExcludeRules()` to convert string codes (e.g., `SC1091`) to integers
- Both `SC1091` and `1091` formats are supported
- Invalid rule codes are gracefully ignored