### PR TITLE
fix(shellscript): skip parse errors in fragments

### DIFF
--- a/internal/validators/file/shellscript.go
+++ b/internal/validators/file/shellscript.go
@@ -48,9 +48,13 @@ func NewShellScriptValidator(
 
 // fragmentExcludes are shellcheck codes to exclude when validating fragments.
 // These are false positives due to limited context:
+// - SC1009: The mentioned syntax error was in... (follow-up to parsing errors)
+// - SC1072: Unexpected token (fragment may start mid-statement)
+// - SC1073: Couldn't parse this (incomplete syntax in fragment)
+// - SC1089: Parsing stopped - keywords not matched (fragment contains partial control structure)
 // - SC2034: variable appears unused (may be used elsewhere in the file)
 // - SC2154: variable is referenced but not assigned (may be assigned elsewhere)
-var fragmentExcludes = []int{2034, 2154}
+var fragmentExcludes = []int{1009, 1072, 1073, 1089, 2034, 2154}
 
 // Validate validates shell scripts using shellcheck.
 func (v *ShellScriptValidator) Validate(


### PR DESCRIPTION
## Motivation

When editing shell scripts with fragments that contain incomplete control structures (like an `else` without its `if`), shellcheck would fail with SC1089 (keywords not matched) because the fragment isn't syntactically complete. This is a false positive since the full file is valid.

## Implementation information

- Add SC1072, SC1073, SC1089 to `fragmentExcludes` for parsing errors that occur due to incomplete syntax in fragments
- Add test case for editing fragment with partial control structure (else block without if)