### PR TITLE
fix(git): clear GIT_INDEX_FILE in test isolation

### DIFF
--- a/internal/validators/git/git_runner_path_test.go
+++ b/internal/validators/git/git_runner_path_test.go
@@ -23,6 +23,7 @@ var gitEnvVars = []string{
 	"GIT_CONFIG",
 	"GIT_CONFIG_GLOBAL",
 	"GIT_CONFIG_SYSTEM",
+	"GIT_INDEX_FILE",
 }
 
 var _ = Describe("CLIGitRunnerWithPath", func() {


### PR DESCRIPTION
## Motivation

Follow-up to #89 which added test isolation for worktrees. The `GIT_INDEX_FILE` environment variable was missed and can cause the parent worktree's index to interfere with test isolation.

## Implementation information

- Add `GIT_INDEX_FILE` to the `gitEnvVars` slice in `git_runner_path_test.go`
- This env var is now cleared alongside other git env vars during test setup