### PR TITLE
ci(gemini): grant contents write permission

### DIFF
--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -25,7 +25,7 @@ jobs:
   invoke:
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
+      contents: write
       id-token: write
       issues: write
       pull-requests: write
@@ -37,7 +37,7 @@ jobs:
         with:
           app-id: ${{ vars.SMYKLOT_APP_ID }}
           private-key: ${{ secrets.SMYKLOT_PRIVATE_KEY }}
-          permission-contents: read
+          permission-contents: write
           permission-issues: write
           permission-pull-requests: write
 


### PR DESCRIPTION
## Motivation

The Gemini CLI needs write access to repository contents to use MCP GitHub server tools for file operations (`create_or_update_file`, `push_files`, `delete_file`).

## Implementation information

- Update job-level permissions from `contents: read` to `contents: write`
- Update `create-github-app-token` action's `permission-contents` from `read` to `write`

> Changelog: skip