### PR TITLE
ci(gemini): grant contents write for invoke

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -152,7 +152,7 @@ jobs:
     if: needs.dispatch.outputs.command == 'invoke'
     uses: ./.github/workflows/gemini-invoke.yml
     permissions:
-      contents: read
+      contents: write
       id-token: write
       issues: write
       pull-requests: write


### PR DESCRIPTION
## Motivation

The `gemini-invoke.yml` reusable workflow requires `contents: write` permission to push commits via MCP GitHub tools, but the caller `gemini-dispatch.yml` was only granting `contents: read`, causing workflow validation failure.

## Implementation information

- Updated `gemini-dispatch.yml` to grant `contents: write` instead of `contents: read` for the `invoke` job

> Changelog: skip