### PR TITLE
ci(gemini): use @gemini instead of @gemini-cli

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -1,5 +1,5 @@
 # Gemini CLI dispatcher workflow
-# Routes @gemini-cli mentions to appropriate handlers (review, triage, invoke)
+# Routes @gemini mentions to appropriate handlers (review, triage, invoke)
 
 name: Gemini Dispatch
 
@@ -43,7 +43,7 @@ jobs:
   dispatch:
     # For PRs: only if not from a fork
     # For issues: only on open/reopen
-    # For comments: only if user types @gemini-cli and is OWNER/MEMBER/COLLABORATOR
+    # For comments: only if user types @gemini and is OWNER/MEMBER/COLLABORATOR
     if: |
       (
         github.event_name == 'pull_request' &&
@@ -53,7 +53,7 @@ jobs:
         contains(fromJSON('["opened", "reopened"]'), github.event.action)
       ) || (
         github.event.sender.type == 'User' &&
-        startsWith(github.event.comment.body || github.event.review.body || github.event.issue.body, '@gemini-cli') &&
+        startsWith(github.event.comment.body || github.event.review.body || github.event.issue.body, '@gemini') &&
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || github.event.review.author_association || github.event.issue.author_association)
       )
     runs-on: ubuntu-24.04
@@ -94,14 +94,14 @@ jobs:
               core.setOutput('command', 'review');
             } else if (['issues.opened', 'issues.reopened'].includes(eventType)) {
               core.setOutput('command', 'triage');
-            } else if (request.startsWith("@gemini-cli /review")) {
+            } else if (request.startsWith("@gemini /review")) {
               core.setOutput('command', 'review');
-              const additionalContext = request.replace(/^@gemini-cli \/review/, '').trim();
+              const additionalContext = request.replace(/^@gemini \/review/, '').trim();
               core.setOutput('additional_context', additionalContext);
-            } else if (request.startsWith("@gemini-cli /triage")) {
+            } else if (request.startsWith("@gemini /triage")) {
               core.setOutput('command', 'triage');
-            } else if (request.startsWith("@gemini-cli")) {
-              const additionalContext = request.replace(/^@gemini-cli/, '').trim();
+            } else if (request.startsWith("@gemini")) {
+              const additionalContext = request.replace(/^@gemini/, '').trim();
               core.setOutput('command', 'invoke');
               core.setOutput('additional_context', additionalContext);
             } else {


### PR DESCRIPTION
## Motivation

Typing `@gemini-cli` in comments is verbose. Using `@gemini` is shorter and more convenient.

## Implementation information

- Updates all occurrences of `@gemini-cli` to `@gemini` in `gemini-dispatch.yml`
- Affects trigger detection, command parsing, and regex replacements