### PR TITLE
docs(claude): add fmt.Errorf to disallowed errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,7 +232,7 @@ Framework: Ginkgo/Gomega. 336 tests. Run: `mise exec -- go test -v ./pkg/parser 
 
 **Linters** (`.golangci.yml`): Nil safety (nilnesserr, govet), completeness (exhaustive, gochecksumtype), quality (gocognit, goconst, cyclop, dupl)
 
-**Error Handling**: NEVER use `errors` or `github.com/pkg/errors`. ALWAYS use `github.com/cockroachdb/errors` for error creation and wrapping
+**Error Handling**: NEVER use `fmt.Errorf`, `errors`, or `github.com/pkg/errors` - linter will reject. ALWAYS use `github.com/cockroachdb/errors` for error creation and wrapping
 
 ## Exit Codes
 


### PR DESCRIPTION
## Summary

- Add `fmt.Errorf` to the list of disallowed error handling approaches in CLAUDE.md
- Note that linter will reject usage

## Motivation

The error handling documentation in CLAUDE.md was incomplete - it mentioned that `errors` and `github.com/pkg/errors` are disallowed, but didn't mention `fmt.Errorf` which is also rejected by the linter.

## Implementation information

- Updated the **Error Handling** line in the Development section of CLAUDE.md

> Changelog: skip