### PR TITLE
ci(workflows): install Claude Code CLI explicitly

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -85,6 +85,9 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code@2.0.55
+
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@a7e4c51380c42dd89b127f5e5f9be7b54020bc6b # v1.0.21
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -63,6 +63,9 @@ jobs:
           git config user.name "smyklot[bot]"
           git config user.email "205507218+smyklot[bot]@users.noreply.github.com"
 
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code@2.0.55
+
       - name: Run Claude Code
         uses: anthropics/claude-code-action@a7e4c51380c42dd89b127f5e5f9be7b54020bc6b # v1.0.21
         with:


### PR DESCRIPTION
## Summary

- Add explicit `npm install -g @anthropic-ai/claude-code@2.0.55` step before running claude-code-action
- Ensures consistent CLI version availability across GitHub Actions runners

## Motivation

GitHub Actions runners may not have Claude Code CLI pre-installed or may have different versions. Installing explicitly before running the action ensures consistent behavior.

## Implementation information

- Added `Install Claude Code CLI` step in `claude.yml` workflow (before Run Claude Code step)
- Added `Install Claude Code CLI` step in `claude-code-review.yml` workflow (before Run Claude Code Review step)
- Pinned to version 2.0.55 for reproducibility