### PR TITLE
ci(workflows): use dedicated GitHub Apps

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -73,6 +73,17 @@ jobs:
       id-token: write
 
     steps:
+      - name: Mint identity token
+        id: mint_identity_token
+        if: vars.CODEX_APP_ID
+        uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2.2.0
+        with:
+          app-id: ${{ vars.CODEX_APP_ID }}
+          private-key: ${{ secrets.CODEX_PRIVATE_KEY }}
+          permission-contents: read
+          permission-issues: write
+          permission-pull-requests: write
+
       - name: Checkout PR merge commit
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
@@ -82,7 +93,7 @@ jobs:
       - name: Get PR head SHA
         id: pr_info
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.mint_identity_token.outputs.token || github.token }}
           PR_NUMBER: ${{ needs.check-trigger.outputs.pr_number }}
         run: |
           pr_info=$(gh pr view "$PR_NUMBER" --json headRefOid,baseRefName,headRefName)
@@ -101,6 +112,7 @@ jobs:
           PR_NUM: ${{ needs.check-trigger.outputs.pr_number }}
           TRIGGER_COMMENT_ID: ${{ github.event.comment.id }}
         with:
+          github-token: ${{ steps.mint_identity_token.outputs.token || github.token }}
           script: |
             const prNumber = Number(process.env.PR_NUM);
             const commentId = process.env.TRIGGER_COMMENT_ID;
@@ -198,6 +210,7 @@ jobs:
           WORKING_COMMENT_ID: ${{ steps.working_comment.outputs.result }}
           TRIGGER_COMMENT_ID: ${{ github.event.comment.id }}
         with:
+          github-token: ${{ steps.mint_identity_token.outputs.token || github.token }}
           script: |
             const fs = require('fs');
             const prNumber = Number(process.env.PR_NUMBER);
@@ -340,6 +353,7 @@ jobs:
           WORKING_COMMENT_ID: ${{ steps.working_comment.outputs.result }}
           TRIGGER_COMMENT_ID: ${{ github.event.comment.id }}
         with:
+          github-token: ${{ steps.mint_identity_token.outputs.token || github.token }}
           script: |
             const prNumber = Number(process.env.PR_NUMBER);
             const workingCommentId = process.env.WORKING_COMMENT_ID;

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -51,11 +51,11 @@ jobs:
     steps:
       - name: Mint identity token
         id: mint_identity_token
-        if: vars.SMYKLOT_APP_ID
+        if: vars.CODEX_APP_ID
         uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
-          private-key: ${{ secrets.SMYKLOT_PRIVATE_KEY }}
+          app-id: ${{ vars.CODEX_APP_ID }}
+          private-key: ${{ secrets.CODEX_PRIVATE_KEY }}
           permission-contents: read
           permission-issues: write
           permission-pull-requests: write

--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -55,11 +55,11 @@ jobs:
     steps:
       - name: Mint identity token
         id: mint_identity_token
-        if: vars.SMYKLOT_APP_ID
+        if: vars.GEMINI_APP_ID
         uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
-          private-key: ${{ secrets.SMYKLOT_PRIVATE_KEY }}
+          app-id: ${{ vars.GEMINI_APP_ID }}
+          private-key: ${{ secrets.GEMINI_PRIVATE_KEY }}
           permission-contents: read
           permission-issues: write
           permission-pull-requests: write
@@ -151,11 +151,11 @@ jobs:
     steps:
       - name: Mint identity token
         id: mint_identity_token
-        if: vars.SMYKLOT_APP_ID
+        if: vars.GEMINI_APP_ID
         uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
-          private-key: ${{ secrets.SMYKLOT_PRIVATE_KEY }}
+          app-id: ${{ vars.GEMINI_APP_ID }}
+          private-key: ${{ secrets.GEMINI_PRIVATE_KEY }}
           permission-contents: read
           permission-issues: write
           permission-pull-requests: write

--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -32,11 +32,11 @@ jobs:
     steps:
       - name: Mint identity token
         id: mint_identity_token
-        if: vars.SMYKLOT_APP_ID
+        if: vars.GEMINI_APP_ID
         uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
-          private-key: ${{ secrets.SMYKLOT_PRIVATE_KEY }}
+          app-id: ${{ vars.GEMINI_APP_ID }}
+          private-key: ${{ secrets.GEMINI_PRIVATE_KEY }}
           permission-contents: write
           permission-issues: write
           permission-pull-requests: write
@@ -44,7 +44,7 @@ jobs:
       - name: Run Gemini CLI
         id: run_gemini
         # Cannot pin by digest: preview action with frequent updates
-        uses: google-github-actions/run-gemini-cli@6f116f01b6bfaf784e5dd71abd1f322f20e03e38 # v0
+        uses: google-github-actions/run-gemini-cli@6f116f01b6bfaf784e5dd71abd1f322f20e03e38 # v0.1.4
         env:
           TITLE: ${{ github.event.pull_request.title || github.event.issue.title }}
           DESCRIPTION: ${{ github.event.pull_request.body || github.event.issue.body }}

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -33,11 +33,11 @@ jobs:
     steps:
       - name: Mint identity token
         id: mint_identity_token
-        if: vars.SMYKLOT_APP_ID
+        if: vars.GEMINI_APP_ID
         uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
-          private-key: ${{ secrets.SMYKLOT_PRIVATE_KEY }}
+          app-id: ${{ vars.GEMINI_APP_ID }}
+          private-key: ${{ secrets.GEMINI_PRIVATE_KEY }}
           permission-contents: read
           permission-issues: write
           permission-pull-requests: write
@@ -47,7 +47,7 @@ jobs:
 
       - name: Run Gemini pull request review
         # Cannot pin by digest: preview action with frequent updates
-        uses: google-github-actions/run-gemini-cli@6f116f01b6bfaf784e5dd71abd1f322f20e03e38 # v0
+        uses: google-github-actions/run-gemini-cli@6f116f01b6bfaf784e5dd71abd1f322f20e03e38 # v0.1.4
         id: gemini_pr_review
         env:
           GITHUB_TOKEN: ${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}

--- a/.github/workflows/gemini-scheduled-triage.yml
+++ b/.github/workflows/gemini-scheduled-triage.yml
@@ -88,7 +88,7 @@ jobs:
         id: gemini_issue_analysis
         if: steps.find_issues.outputs.issues_to_triage != '[]'
         # Cannot pin by digest: preview action with frequent updates
-        uses: google-github-actions/run-gemini-cli@6f116f01b6bfaf784e5dd71abd1f322f20e03e38 # v0
+        uses: google-github-actions/run-gemini-cli@6f116f01b6bfaf784e5dd71abd1f322f20e03e38 # v0.1.4
         env:
           GITHUB_TOKEN: '' # Do not pass any auth token here since this runs on untrusted inputs
           ISSUES_TO_TRIAGE: ${{ steps.find_issues.outputs.issues_to_triage }}
@@ -143,11 +143,11 @@ jobs:
     steps:
       - name: Mint identity token
         id: mint_identity_token
-        if: vars.SMYKLOT_APP_ID
+        if: vars.GEMINI_APP_ID
         uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
-          private-key: ${{ secrets.SMYKLOT_PRIVATE_KEY }}
+          app-id: ${{ vars.GEMINI_APP_ID }}
+          private-key: ${{ secrets.GEMINI_PRIVATE_KEY }}
           permission-contents: read
           permission-issues: write
           permission-pull-requests: write

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -64,7 +64,7 @@ jobs:
         id: gemini_analysis
         if: steps.get_labels.outputs.available_labels != ''
         # Cannot pin by digest: preview action with frequent updates
-        uses: google-github-actions/run-gemini-cli@6f116f01b6bfaf784e5dd71abd1f322f20e03e38 # v0
+        uses: google-github-actions/run-gemini-cli@6f116f01b6bfaf784e5dd71abd1f322f20e03e38 # v0.1.4
         env:
           GITHUB_TOKEN: '' # Do NOT pass any auth tokens here since this runs on untrusted inputs
           ISSUE_TITLE: ${{ github.event.issue.title }}
@@ -113,11 +113,11 @@ jobs:
     steps:
       - name: Mint identity token
         id: mint_identity_token
-        if: vars.SMYKLOT_APP_ID
+        if: vars.GEMINI_APP_ID
         uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2.2.0
         with:
-          app-id: ${{ vars.SMYKLOT_APP_ID }}
-          private-key: ${{ secrets.SMYKLOT_PRIVATE_KEY }}
+          app-id: ${{ vars.GEMINI_APP_ID }}
+          private-key: ${{ secrets.GEMINI_PRIVATE_KEY }}
           permission-contents: read
           permission-issues: write
           permission-pull-requests: write


### PR DESCRIPTION
## Summary

- Replace generic SMYKLOT bot credentials with dedicated app credentials for better identity separation
- Codex workflows now use `CODEX_APP_ID` / `CODEX_PRIVATE_KEY`
- Gemini workflows now use `GEMINI_APP_ID` / `GEMINI_PRIVATE_KEY`
- Bot actions will now appear under the appropriate app name

## Motivation

Each AI assistant (Codex, Gemini) should have its own GitHub App identity so that comments, reactions, and reviews appear under the correct bot name rather than a generic "smyklot" account.

## Implementation information

- Created org variables: `CODEX_APP_ID` (2384221), `GEMINI_APP_ID` (2384300)
- Created org secrets: `CODEX_PRIVATE_KEY`, `GEMINI_PRIVATE_KEY`
- Updated 7 workflow files to use the new credentials with fallback to `github.token`
- Fixed `run-gemini-cli` version comments to pass actionlint (`# v0` → `# v0.1.4`)