### PR TITLE
ci(codex): pass GH_TOKEN to codex action

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -141,6 +141,7 @@ jobs:
         id: run_codex
         uses: openai/codex-action@086169432f1d2ab2f4057540b1754d550f6a1189 # v1.4
         env:
+          GH_TOKEN: ${{ steps.mint_identity_token.outputs.token || github.token }}
           PR_NUMBER: ${{ needs.check-trigger.outputs.pr_number }}
           REPOSITORY: ${{ github.repository }}
         with:


### PR DESCRIPTION
## Motivation

The Codex bot was failing with "gh requires GH_TOKEN" error when trying to review PRs because the token wasn't passed to its environment.

## Implementation information

- Add `GH_TOKEN` to the Codex action's `env` block using the minted app token (with fallback to `github.token`)

> Changelog: skip