### PR TITLE
fix(ci): pin ruff version to 0.14.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           python-version: '3.13'
 
       - name: Install ruff
-        run: pip install ruff
+        run: pip install ruff==0.14.7
 
       - name: Download dependencies
         run: go mod download


### PR DESCRIPTION
## Description

Pin ruff package version in CI workflow to address security alert about unpinned dependencies.

## Changes

- Pin ruff to version 0.14.7 in `.github/workflows/ci.yml`

## Security

Fixes security alert #21 (Pinned-Dependencies)

This improves supply chain security and build reproducibility by ensuring a specific version of ruff is installed rather than allowing any version.