### PR TITLE
ci(nix-vendor-hash): get file SHA from local git

### DIFF
--- a/.github/workflows/nix-vendor-hash.yml
+++ b/.github/workflows/nix-vendor-hash.yml
@@ -79,12 +79,8 @@ jobs:
           SHORT_HASH=$(echo "$NEW_HASH" | sed 's/sha256-//' | cut -c1-12)
           COMMIT_MSG="build(nix): update vendorHash to ${SHORT_HASH}"
 
-          # Get current file SHA from GitHub
-          FILE_SHA=$(gh api repos/${{ github.repository }}/contents/nix/package.nix \
-            --jq '.sha' \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            -f ref=${{ github.head_ref }})
+          # Get current file SHA from local git (blob SHA from index)
+          FILE_SHA=$(git ls-files -s nix/package.nix | awk '{print $2}')
 
           # Base64 encode the updated file content
           CONTENT=$(base64 -w 0 nix/package.nix)


### PR DESCRIPTION
## Summary

Fixes 404 error when getting file SHA from GitHub API by using local git repository instead.

## Motivation

The workflow was failing with HTTP 404 when trying to get the file SHA from GitHub API for branches with slashes in their names (like `renovate/github.com-go-git-go-git-v6-6.x`). Since the file is already checked out locally, we can get the blob SHA directly from the local git index.

Fixes: https://github.com/smykla-labs/klaudiush/actions/runs/19876129761/job/56963827467?pr=147

## Implementation information

- Use `git ls-files -s` to get blob SHA from local git index
- Removes dependency on GitHub API call for file SHA retrieval
- Avoids URL encoding issues with branch names containing slashes