### PR TITLE
ci(workflow): fix script injection vulnerability

### DIFF
--- a/.github/workflows/nix-vendor-hash.yml
+++ b/.github/workflows/nix-vendor-hash.yml
@@ -74,6 +74,8 @@ jobs:
         env:
           NEW_HASH: ${{ steps.calc-hash.outputs.new_hash }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           # Extract short hash (first 12 chars after sha256-)
           SHORT_HASH=$(echo "$NEW_HASH" | sed 's/sha256-//' | cut -c1-12)
@@ -86,11 +88,11 @@ jobs:
           CONTENT=$(base64 -w 0 nix/package.nix)
 
           # Update file via GitHub API (creates verified commit)
-          gh api repos/${{ github.repository }}/contents/nix/package.nix \
+          gh api "repos/${GITHUB_REPOSITORY}/contents/nix/package.nix" \
             --method PUT \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             -f message="$COMMIT_MSG" \
             -f content="$CONTENT" \
             -f sha="$FILE_SHA" \
-            -f branch=${{ github.head_ref }}
+            -f branch="$HEAD_REF"


### PR DESCRIPTION
# Summary

- Fixed critical script injection vulnerability in `.github/workflows/nix-vendor-hash.yml`
- Moved untrusted inputs `github.head_ref` and `github.repository` from direct script interpolation to environment variables

## Motivation

CodeQL/Scorecard detected a critical security vulnerability (alert #24) where untrusted input `github.head_ref` was used directly in a shell script. An attacker could create a pull request with a malicious branch name containing shell commands (e.g., `$(rm -rf /)`) which would be executed during the workflow run. This vulnerability could lead to repository compromise, secret exfiltration, or supply chain attacks.

## Implementation information

- Changed line 96 in `.github/workflows/nix-vendor-hash.yml` to use `$HEAD_REF` environment variable instead of `${{ github.head_ref }}`
- Changed line 91 to use `$GITHUB_REPOSITORY` environment variable instead of `${{ github.repository }}`
- Added `HEAD_REF` and `GITHUB_REPOSITORY` to the `env:` block (lines 77-78)
- Environment variables are treated as literal strings by the shell, preventing command injection even with malicious input

## Supporting documentation

- [CodeQL Alert #24](https://github.com/smykla-labs/klaudiush/security/code-scanning/24)
- [GitHub Security Hardening Guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections)