### PR TITLE
fix(markdown): enforce MD022 for lists

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,6 @@ github.com/go-git/go-billy/v6 v6.0.0-20251120215217-80673c4ccbfb h1:DMxvYQ9F7gtl
 github.com/go-git/go-billy/v6 v6.0.0-20251120215217-80673c4ccbfb/go.mod h1:0NjwVNrwtVFZBReAp5OoGklGJIgJFEbVyHneAr4lc8k=
 github.com/go-git/go-git-fixtures/v5 v5.1.1 h1:OH8i1ojV9bWfr0ZfasfpgtUXQHQyVS8HXik/V1C099w=
 github.com/go-git/go-git-fixtures/v5 v5.1.1/go.mod h1:Altk43lx3b1ks+dVoAG2300o5WWUnktvfY3VI6bcaXU=
-github.com/go-git/go-git/v6 v6.0.0-20251125231338-2d242db0996d h1:/rZhs/y1Klfmi6PsVRyiZUC8BlO9cyzPyOGF2W1+kbY=
-github.com/go-git/go-git/v6 v6.0.0-20251125231338-2d242db0996d/go.mod h1:dIwT3uWK1ooHInyVnK2JS5VfQ3peVGYaw2QPqX7uFvs=
 github.com/go-git/go-git/v6 v6.0.0-20251202212438-5d40cdde8ca0 h1:v0Mxdd5R1H0slVEBQiJNhLZdWu7BBjb8BRdRrUPJzmg=
 github.com/go-git/go-git/v6 v6.0.0-20251202212438-5d40cdde8ca0/go.mod h1:dIwT3uWK1ooHInyVnK2JS5VfQ3peVGYaw2QPqX7uFvs=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=

--- a/internal/validators/file/markdown_test.go
+++ b/internal/validators/file/markdown_test.go
@@ -74,14 +74,28 @@ More text.
 				Expect(result.Passed).To(BeTrue())
 			})
 
-			It("passes for list after header", func() {
+			It("passes for list after header with blank line", func() {
 				content := `## Features
+
 - Feature 1
 - Feature 2
 `
 				ctx.ToolInput.Content = content
 				result := v.Validate(context.Background(), ctx)
 				Expect(result.Passed).To(BeTrue())
+			})
+
+			It("fails for list directly after header without blank line", func() {
+				content := `## Features
+- Feature 1
+- Feature 2
+`
+				ctx.ToolInput.Content = content
+				result := v.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeFalse())
+				Expect(result.Details["errors"]).To(
+					ContainSubstring("Header should have empty line after it"),
+				)
 			})
 
 			It("passes for consecutive headers", func() {

--- a/internal/validators/markdown_utils.go
+++ b/internal/validators/markdown_utils.go
@@ -655,13 +655,13 @@ func checkHeader(line, prevLine string, lineNum int, warnings *[]string) {
 	}
 }
 
-// shouldWarnAboutHeaderSpacing determines if content after a header needs spacing
+// shouldWarnAboutHeaderSpacing determines if content after a header needs spacing.
+// Per MD022, blank lines are required around ALL headings, including before lists.
 func shouldWarnAboutHeaderSpacing(line string) bool {
 	return line != "" &&
 		!isEmptyLine(line) &&
 		!isHeader(line) &&
-		!isComment(line) &&
-		!isListItem(line)
+		!isComment(line)
 }
 
 // getListIndent calculates the required indentation for list item content


### PR DESCRIPTION
## Motivation

The `shouldWarnAboutHeaderSpacing()` function explicitly exempted list items from the blank-line-after-header check. This meant markdown like `### Header` followed directly by `- List item` would pass validation, violating MD022 (blanks around headings).

## Implementation information

- Removed `!isListItem(line)` exception from `shouldWarnAboutHeaderSpacing()` in `markdown_utils.go`
- Updated test "passes for list after header" to require blank line in content
- Added new test "fails for list directly after header without blank line"

> Changelog: skip