### PR TITLE
feat(push): add blocked_branches

### DIFF
--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -239,6 +239,7 @@ func DefaultPushValidatorConfig() *config.PushValidatorConfig {
 			Severity: config.SeverityError,
 		},
 		BlockedRemotes:  []string{},
+		BlockedBranches: []string{},
 		RequireTracking: &requireTracking,
 	}
 }

--- a/internal/templates/git.go
+++ b/internal/templates/git.go
@@ -125,6 +125,14 @@ Suggested alternatives: [{{.SuggestedRemotesStr}}]
 Available remotes: [{{.AvailableRemotesStr}}]
 {{- end}}`,
 	)
+
+	// PushBlockedBranchTemplate formats error for push to blocked branch
+	PushBlockedBranchTemplate = Parse(
+		"push_blocked_branch",
+		`❌ Branch '{{.Branch}}' is blocked for push operations
+
+Blocked branches: [{{.BlockedBranchesStr}}]`,
+	)
 )
 
 // GitAddTmpFilesData holds data for GitAddTmpFilesTemplate
@@ -183,4 +191,10 @@ type PushBlockedRemoteData struct {
 	BlockedRemotesStr   string
 	SuggestedRemotesStr string
 	AvailableRemotesStr string
+}
+
+// PushBlockedBranchData holds data for PushBlockedBranchTemplate
+type PushBlockedBranchData struct {
+	Branch             string
+	BlockedBranchesStr string
 }

--- a/internal/validator/reference.go
+++ b/internal/validator/reference.go
@@ -85,6 +85,9 @@ const (
 
 	// RefGitBlockedRemote indicates push to a blocked remote.
 	RefGitBlockedRemote Reference = ReferenceBaseURL + "/GIT025"
+
+	// RefGitBlockedBranch indicates push to a blocked branch.
+	RefGitBlockedBranch Reference = ReferenceBaseURL + "/GIT026"
 )
 
 // File-related references (FILE001-FILE009).

--- a/internal/validator/suggestions.go
+++ b/internal/validator/suggestions.go
@@ -31,6 +31,7 @@ var DefaultSuggestions = map[Reference]string{
 	RefGitPRValidation:       "Fix the issue and retry gh pr create",
 	RefGitFetchNoRemote:      "Specify valid remote: git fetch <remote> (use 'git remote -v' to list remotes)",
 	RefGitBlockedRemote:      "Use an allowed remote for push",
+	RefGitBlockedBranch:      "Push to a different branch or create a PR",
 
 	// File suggestions
 	RefShellcheck:   "Run 'shellcheck <file>' to see detailed errors",

--- a/internal/validators/git/push.go
+++ b/internal/validators/git/push.go
@@ -90,9 +90,11 @@ func (v *PushValidator) validatePushCommand(
 	}
 
 	// Check if branch is blocked
-	branch := v.extractBranch(gitCmd, runner)
-	if result := v.validateNotBlockedBranch(branch); !result.Passed {
-		return result
+	if v.config != nil && len(v.config.BlockedBranches) > 0 {
+		branch := v.extractBranch(gitCmd, runner)
+		if result := v.validateNotBlockedBranch(branch); !result.Passed {
+			return result
+		}
 	}
 
 	// Skip remote existence check if a preceding command adds this remote
@@ -232,25 +234,47 @@ func (v *PushValidator) validateNotBlockedRemote(
 	return result
 }
 
-// extractBranch extracts the target branch name from a git push command
-func (*PushValidator) extractBranch(gitCmd *parser.GitCommand, runner GitRunner) string {
-	if len(gitCmd.Args) > 1 {
-		branch := gitCmd.Args[1]
-		// Handle refspec: src:dst → use dst (target branch)
-		if idx := strings.Index(branch, ":"); idx >= 0 {
-			branch = branch[idx+1:]
+// parseBranchFromRefspec extracts and normalizes the target branch from a refspec.
+func parseBranchFromRefspec(refspec string) string {
+	branch := refspec
+	if _, dst, ok := strings.Cut(refspec, ":"); ok {
+		branch = dst
+	}
+
+	return strings.TrimPrefix(branch, "refs/heads/")
+}
+
+// extractBranch extracts the target branch name from a git push command.
+// When multiple refspecs are provided, returns a blocked branch first
+// so downstream validation can deny the push.
+func (v *PushValidator) extractBranch(gitCmd *parser.GitCommand, runner GitRunner) string {
+	if len(gitCmd.Args) <= 1 {
+		branch, err := runner.GetCurrentBranch()
+		if err != nil {
+			return ""
 		}
 
 		return branch
 	}
 
-	// No branch arg → use current branch
-	branch, err := runner.GetCurrentBranch()
-	if err != nil {
-		return ""
+	var firstBranch string
+
+	for _, refspec := range gitCmd.Args[1:] {
+		branch := parseBranchFromRefspec(refspec)
+		if branch == "" {
+			continue
+		}
+
+		if firstBranch == "" {
+			firstBranch = branch
+		}
+
+		if v.config != nil && slices.Contains(v.config.BlockedBranches, branch) {
+			return branch
+		}
 	}
 
-	return branch
+	return firstBranch
 }
 
 // validateNotBlockedBranch checks if the branch is blocked

--- a/internal/validators/git/push.go
+++ b/internal/validators/git/push.go
@@ -89,6 +89,12 @@ func (v *PushValidator) validatePushCommand(
 		return result
 	}
 
+	// Check if branch is blocked
+	branch := v.extractBranch(gitCmd, runner)
+	if result := v.validateNotBlockedBranch(branch); !result.Passed {
+		return result
+	}
+
 	// Skip remote existence check if a preceding command adds this remote
 	if pendingRemotes[remote] {
 		v.Logger().
@@ -224,6 +230,51 @@ func (v *PushValidator) validateNotBlockedRemote(
 	}
 
 	return result
+}
+
+// extractBranch extracts the target branch name from a git push command
+func (*PushValidator) extractBranch(gitCmd *parser.GitCommand, runner GitRunner) string {
+	if len(gitCmd.Args) > 1 {
+		branch := gitCmd.Args[1]
+		// Handle refspec: src:dst → use dst (target branch)
+		if idx := strings.Index(branch, ":"); idx >= 0 {
+			branch = branch[idx+1:]
+		}
+
+		return branch
+	}
+
+	// No branch arg → use current branch
+	branch, err := runner.GetCurrentBranch()
+	if err != nil {
+		return ""
+	}
+
+	return branch
+}
+
+// validateNotBlockedBranch checks if the branch is blocked
+func (v *PushValidator) validateNotBlockedBranch(branch string) *validator.Result {
+	if v.config == nil || len(v.config.BlockedBranches) == 0 || branch == "" {
+		return validator.Pass()
+	}
+
+	if !slices.Contains(v.config.BlockedBranches, branch) {
+		return validator.Pass()
+	}
+
+	blockedBranchesStr := strings.Join(v.config.BlockedBranches, ", ")
+
+	return validator.FailWithRef(
+		validator.RefGitBlockedBranch,
+		templates.MustExecute(
+			templates.PushBlockedBranchTemplate,
+			templates.PushBlockedBranchData{
+				Branch:             branch,
+				BlockedBranchesStr: blockedBranchesStr,
+			},
+		),
+	)
 }
 
 // validateRemoteExists checks if the remote exists

--- a/internal/validators/git/push_test.go
+++ b/internal/validators/git/push_test.go
@@ -401,6 +401,28 @@ var _ = Describe("PushValidator", func() {
 				Expect(result.Passed).To(BeTrue())
 			})
 
+			It("blocks when blocked branch is second refspec", func() {
+				cfg := &config.PushValidatorConfig{}
+				cfg.BlockedBranches = []string{"main"}
+				validator = git.NewPushValidator(log, fakeGit, cfg, nil)
+
+				ctx := createContext("git push origin feature main")
+				result := validator.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeFalse())
+				Expect(result.Message).To(ContainSubstring("Branch 'main' is blocked"))
+			})
+
+			It("blocks refspec with refs/heads/ prefix", func() {
+				cfg := &config.PushValidatorConfig{}
+				cfg.BlockedBranches = []string{"main"}
+				validator = git.NewPushValidator(log, fakeGit, cfg, nil)
+
+				ctx := createContext("git push origin HEAD:refs/heads/main")
+				result := validator.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeFalse())
+				Expect(result.Message).To(ContainSubstring("Branch 'main' is blocked"))
+			})
+
 			It("passes when no blocked branches configured", func() {
 				cfg := &config.PushValidatorConfig{}
 				validator = git.NewPushValidator(log, fakeGit, cfg, nil)

--- a/internal/validators/git/push_test.go
+++ b/internal/validators/git/push_test.go
@@ -345,6 +345,80 @@ var _ = Describe("PushValidator", func() {
 			})
 		})
 
+		Context("blocked branches", func() {
+			It("blocks push to configured blocked branch", func() {
+				cfg := &config.PushValidatorConfig{}
+				cfg.BlockedBranches = []string{"main", "master"}
+				validator = git.NewPushValidator(log, fakeGit, cfg, nil)
+
+				ctx := createContext("git push origin main")
+				result := validator.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeFalse())
+				Expect(result.Message).To(ContainSubstring("Branch 'main' is blocked"))
+				Expect(result.Message).To(ContainSubstring("Blocked branches: [main, master]"))
+			})
+
+			It("allows push to non-blocked branch", func() {
+				cfg := &config.PushValidatorConfig{}
+				cfg.BlockedBranches = []string{"main", "master"}
+				validator = git.NewPushValidator(log, fakeGit, cfg, nil)
+
+				ctx := createContext("git push origin feature/my-branch")
+				result := validator.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeTrue())
+			})
+
+			It("detects branch from current branch when no args", func() {
+				cfg := &config.PushValidatorConfig{}
+				cfg.BlockedBranches = []string{"main"}
+				fakeGit.CurrentBranch = "main"
+				validator = git.NewPushValidator(log, fakeGit, cfg, nil)
+
+				ctx := createContext("git push")
+				result := validator.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeFalse())
+				Expect(result.Message).To(ContainSubstring("Branch 'main' is blocked"))
+			})
+
+			It("handles refspec format src:dst", func() {
+				cfg := &config.PushValidatorConfig{}
+				cfg.BlockedBranches = []string{"main"}
+				validator = git.NewPushValidator(log, fakeGit, cfg, nil)
+
+				ctx := createContext("git push origin HEAD:main")
+				result := validator.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeFalse())
+				Expect(result.Message).To(ContainSubstring("Branch 'main' is blocked"))
+			})
+
+			It("allows refspec when target branch is not blocked", func() {
+				cfg := &config.PushValidatorConfig{}
+				cfg.BlockedBranches = []string{"main"}
+				validator = git.NewPushValidator(log, fakeGit, cfg, nil)
+
+				ctx := createContext("git push origin main:feature")
+				result := validator.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeTrue())
+			})
+
+			It("passes when no blocked branches configured", func() {
+				cfg := &config.PushValidatorConfig{}
+				validator = git.NewPushValidator(log, fakeGit, cfg, nil)
+
+				ctx := createContext("git push origin main")
+				result := validator.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeTrue())
+			})
+
+			It("passes when config is nil", func() {
+				validator = git.NewPushValidator(log, fakeGit, nil, nil)
+
+				ctx := createContext("git push origin main")
+				result := validator.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeTrue())
+			})
+		})
+
 		Context("compound commands with git remote add", func() {
 			It("passes when remote is added in a preceding command", func() {
 				ctx := createContext(

--- a/pkg/config/git.go
+++ b/pkg/config/git.go
@@ -137,6 +137,11 @@ type PushValidatorConfig struct {
 	// Default: ["origin", "upstream"]
 	AllowedRemotePriority []string `json:"allowed_remote_priority,omitempty" koanf:"allowed_remote_priority" toml:"allowed_remote_priority,omitempty"`
 
+	// BlockedBranches is a list of branch names that are not allowed for push operations.
+	// When Claude Code tries to push to a blocked branch, the operation will be rejected.
+	// Default: []
+	BlockedBranches []string `json:"blocked_branches,omitempty" koanf:"blocked_branches" toml:"blocked_branches,omitempty"`
+
 	// RequireTracking requires branches to have remote tracking configured before push.
 	// Default: true
 	RequireTracking *bool `json:"require_tracking,omitempty" koanf:"require_tracking" toml:"require_tracking,omitempty"`


### PR DESCRIPTION
## Motivation

PushValidator blocks by remote name (`blocked_remotes`) but has no way to block pushes to specific branches (e.g. `main`, `master`). This is a common workflow protection — prevent direct pushes to protected branches, forcing PRs instead.

## Implementation information

Mirrors the existing `blocked_remotes` pattern:

- `BlockedBranches []string` config field in `PushValidatorConfig`
- `GIT026` error code with template and suggestion
- `extractBranch()` handles: explicit branch arg, refspec (`src:dst`), and implicit current branch
- `validateNotBlockedBranch()` checks against config list
- Validation runs after remote check, before remote existence check

Usage:
```toml
[validators.git.push]
blocked_branches = ["main", "master"]
```

No `AllowedBranchPriority` — unlike remotes, there's no meaningful "suggest this branch instead" behavior.

## Supporting documentation

- Follows same pattern as `blocked_remotes` (GIT025)