### PR TITLE
fix(git): validate commit messages fed via -F -

### DIFF
--- a/internal/validators/git/commit.go
+++ b/internal/validators/git/commit.go
@@ -300,6 +300,14 @@ func (*CommitValidator) hasGitAddInChain(commands []parser.Command) bool {
 func (v *CommitValidator) extractCommitMessage(gitCmd *parser.GitCommand) (string, error) {
 	// Check for file flags first (-F/--file)
 	if filePath := v.getFlagValue(gitCmd, commitFileFlags); filePath != "" {
+		// "-" means read from stdin. The parser captures stdin fed via a
+		// heredoc or a piped echo/printf, so validate that when available.
+		if filePath == "-" {
+			v.Logger().Debug("Reading commit message from stdin (-F -)")
+
+			return strings.TrimSpace(gitCmd.Stdin), nil
+		}
+
 		v.Logger().Debug("Reading commit message from file", "path", filePath)
 
 		content, err := os.ReadFile(

--- a/internal/validators/git/commit.go
+++ b/internal/validators/git/commit.go
@@ -303,9 +303,18 @@ func (v *CommitValidator) extractCommitMessage(gitCmd *parser.GitCommand) (strin
 		// "-" means read from stdin. The parser captures stdin fed via a
 		// heredoc or a piped echo/printf, so validate that when available.
 		if filePath == "-" {
+			stdin := strings.TrimSpace(gitCmd.Stdin)
+			if stdin == "" {
+				// Stdin wasn't capturable (e.g. message piped from a process
+				// the parser can't read); treat it like no inline message.
+				v.Logger().Debug("Commit message comes from uncaptured stdin (-F -)")
+
+				return "", nil
+			}
+
 			v.Logger().Debug("Reading commit message from stdin (-F -)")
 
-			return strings.TrimSpace(gitCmd.Stdin), nil
+			return stdin, nil
 		}
 
 		v.Logger().Debug("Reading commit message from file", "path", filePath)

--- a/internal/validators/git/commit_test.go
+++ b/internal/validators/git/commit_test.go
@@ -1125,6 +1125,66 @@ Signed-off-by: Test User <test@klaudiu.sh>`
 			Expect(result.Message).To(ContainSubstring("Failed to read commit message"))
 		})
 
+		It("should not warn when -F - has no stdin (message from editor)", func() {
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{
+					Command: `git commit -sS -a -F -`,
+				},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeTrue())
+			Expect(result.ShouldBlock).To(BeFalse())
+			Expect(result.Message).ToNot(ContainSubstring("Failed to read commit message"))
+		})
+
+		It("should validate message from a heredoc fed to -F -", func() {
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{
+					Command: "git commit -sS -a -F - <<'EOF'\nthis is not conventional\nEOF",
+				},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeFalse())
+			Expect(
+				result.Message,
+			).To(ContainSubstring("doesn't follow conventional commits format"))
+		})
+
+		It("should pass a valid message from a heredoc fed to -F -", func() {
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{
+					Command: "git commit -sS -a -F - <<'EOF'\nfix(parser): handle stdin commit messages\nEOF",
+				},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeTrue())
+		})
+
+		It("should validate message piped to -F - via echo", func() {
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{
+					Command: `echo "this is not conventional" | git commit -sS -a -F -`,
+				},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeFalse())
+			Expect(
+				result.Message,
+			).To(ContainSubstring("doesn't follow conventional commits format"))
+		})
+
 		It("should pass with empty file (message from editor)", func() {
 			file, err := os.CreateTemp("", "commit-msg-*.txt")
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/validators/git/commit_test.go
+++ b/internal/validators/git/commit_test.go
@@ -1156,6 +1156,23 @@ Signed-off-by: Test User <test@klaudiu.sh>`
 			).To(ContainSubstring("doesn't follow conventional commits format"))
 		})
 
+		It("should validate a heredoc message even with an output redirect", func() {
+			// An output redirect must not let -F - bypass message validation.
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{
+					Command: "git commit -sS -a -F - <<'EOF' >/dev/null\nthis is not conventional\nEOF",
+				},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeFalse())
+			Expect(
+				result.Message,
+			).To(ContainSubstring("doesn't follow conventional commits format"))
+		})
+
 		It("should pass a valid message from a heredoc fed to -F -", func() {
 			ctx := &hook.Context{
 				EventType: hook.EventTypePreToolUse,

--- a/internal/validators/git/commit_test.go
+++ b/internal/validators/git/commit_test.go
@@ -1219,18 +1219,37 @@ Signed-off-by: Test User <test@klaudiu.sh>`
 		})
 
 		It("should keep dash-prefixed words when echo feeds -F -", func() {
-			// echo only treats the leading -n/-e/-E run as flags; "-prefixed"
-			// here is part of the message and must not be dropped.
+			// echo only treats the leading -n/-e/-E run as flags; a -prefixed
+			// word appearing after a non-flag arg is literal and must survive.
+			// "-dash" is its own echo argument here, so it exercises the
+			// flag-stripping boundary rather than a quoted substring.
 			ctx := &hook.Context{
 				EventType: hook.EventTypePreToolUse,
 				ToolName:  hook.ToolTypeBash,
 				ToolInput: hook.ToolInput{
-					Command: `echo "fix(parser): handle -prefixed words" | git commit -sS -a -F -`,
+					Command: `echo "fix(parser): handle" -dash words | git commit -sS -a -F -`,
 				},
 			}
 
 			result := validator.Validate(context.Background(), ctx)
 			Expect(result.Passed).To(BeTrue())
+		})
+
+		It("should not capture echo -e output (escape interpretation)", func() {
+			// echo -e interprets backslash escapes, which the parser does not
+			// replicate, so the message is treated as uncaptured (editor case)
+			// rather than validated against raw text.
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{
+					Command: `echo -e "this is not conventional" | git commit -sS -a -F -`,
+				},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeTrue())
+			Expect(result.Message).ToNot(ContainSubstring("conventional commits format"))
 		})
 
 		It("should pass with empty file (message from editor)", func() {

--- a/internal/validators/git/commit_test.go
+++ b/internal/validators/git/commit_test.go
@@ -1185,6 +1185,37 @@ Signed-off-by: Test User <test@klaudiu.sh>`
 			).To(ContainSubstring("doesn't follow conventional commits format"))
 		})
 
+		It("should validate message piped to -F - via printf %s", func() {
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{
+					Command: `printf '%s' "this is not conventional" | git commit -sS -a -F -`,
+				},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeFalse())
+			Expect(
+				result.Message,
+			).To(ContainSubstring("doesn't follow conventional commits format"))
+		})
+
+		It("should keep dash-prefixed words when echo feeds -F -", func() {
+			// echo only treats the leading -n/-e/-E run as flags; "-prefixed"
+			// here is part of the message and must not be dropped.
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{
+					Command: `echo "fix(parser): handle -prefixed words" | git commit -sS -a -F -`,
+				},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeTrue())
+		})
+
 		It("should pass with empty file (message from editor)", func() {
 			file, err := os.CreateTemp("", "commit-msg-*.txt")
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/validators/git/commit_test.go
+++ b/internal/validators/git/commit_test.go
@@ -1235,6 +1235,22 @@ Signed-off-by: Test User <test@klaudiu.sh>`
 			Expect(result.Passed).To(BeTrue())
 		})
 
+		It("should not capture echo output containing an expansion", func() {
+			// "$VAR" cannot be resolved by the parser, so the message must be
+			// treated as uncaptured rather than validated against partial text.
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{
+					Command: `echo "this is not conventional $VAR" | git commit -sS -a -F -`,
+				},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeTrue())
+			Expect(result.Message).ToNot(ContainSubstring("conventional commits format"))
+		})
+
 		It("should not capture echo -e output (escape interpretation)", func() {
 			// echo -e interprets backslash escapes, which the parser does not
 			// replicate, so the message is treated as uncaptured (editor case)

--- a/pkg/parser/ast_walker.go
+++ b/pkg/parser/ast_walker.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"strings"
+
 	"mvdan.cc/sh/v3/syntax"
 )
 
@@ -9,11 +11,17 @@ type astWalker struct {
 	commands   []Command
 	fileWrites []FileWrite
 	currentDir string // Tracks the effective working directory from cd commands
+	// stdinByCall maps a CallExpr to the content fed to its stdin (heredoc or
+	// piped echo/printf). Populated when a Stmt or pipeline is visited, then
+	// consumed when the corresponding CallExpr is extracted into a Command.
+	stdinByCall map[*syntax.CallExpr]string
 }
 
 // visit is called for each node in the AST.
 func (w *astWalker) visit(node syntax.Node) bool {
 	switch n := node.(type) {
+	case *syntax.BinaryCmd:
+		w.extractPipedStdin(n)
 	case *syntax.CallExpr:
 		w.extractCommand(n)
 	case *syntax.Stmt:
@@ -27,6 +35,88 @@ func (w *astWalker) visit(node syntax.Node) bool {
 	}
 
 	return true
+}
+
+// recordStdin associates stdin content with a CallExpr so it can be attached
+// to the Command when that CallExpr is later extracted.
+func (w *astWalker) recordStdin(call *syntax.CallExpr, content string) {
+	if w.stdinByCall == nil {
+		w.stdinByCall = make(map[*syntax.CallExpr]string)
+	}
+
+	w.stdinByCall[call] = content
+}
+
+// extractPipedStdin handles "producer | consumer" pipelines, capturing the
+// producer's literal output (echo/printf) as the consumer's stdin. This lets
+// validators inspect messages fed via "git commit -F -".
+func (w *astWalker) extractPipedStdin(bin *syntax.BinaryCmd) {
+	if bin.Op != syntax.Pipe && bin.Op != syntax.PipeAll {
+		return
+	}
+
+	producer := callExprOf(bin.X)
+	consumer := callExprOf(bin.Y)
+
+	if producer == nil || consumer == nil {
+		return
+	}
+
+	content, ok := literalCommandOutput(producer)
+	if !ok {
+		return
+	}
+
+	w.recordStdin(consumer, content)
+}
+
+// callExprOf returns the CallExpr a statement runs, or nil if the statement is
+// not a simple command.
+func callExprOf(stmt *syntax.Stmt) *syntax.CallExpr {
+	if stmt == nil {
+		return nil
+	}
+
+	if call, ok := stmt.Cmd.(*syntax.CallExpr); ok {
+		return call
+	}
+
+	return nil
+}
+
+// literalCommandOutput returns the text a simple echo/printf command writes to
+// stdout, when it can be determined from literal arguments alone.
+func literalCommandOutput(call *syntax.CallExpr) (string, bool) {
+	if len(call.Args) == 0 {
+		return "", false
+	}
+
+	name := wordToString(call.Args[0])
+
+	args := wordsToStrings(call.Args[1:])
+
+	switch name {
+	case "echo":
+		// Drop echo flags (-n, -e, ...); join remaining args with spaces.
+		var parts []string
+
+		for _, arg := range args {
+			if len(arg) > 0 && arg[0] == '-' {
+				continue
+			}
+
+			parts = append(parts, arg)
+		}
+
+		return strings.Join(parts, " "), true
+	case "printf":
+		// Only handle the trivial "printf <format>" form with no directives.
+		if len(args) == 1 && !strings.Contains(args[0], "%") {
+			return args[0], true
+		}
+	}
+
+	return "", false
 }
 
 // extractCommand extracts a command from a CallExpr node.
@@ -59,6 +149,7 @@ func (w *astWalker) extractCommand(call *syntax.CallExpr) {
 		Location:         loc,
 		Type:             cmdType,
 		WorkingDirectory: w.currentDir,
+		Stdin:            w.stdinByCall[call],
 	}
 
 	w.commands = append(w.commands, cmd)
@@ -72,83 +163,86 @@ func (w *astWalker) extractCommand(call *syntax.CallExpr) {
 	w.extractFileWriteCommand(cmd)
 }
 
-// extractRedirect extracts file write operations from redirections.
-func (w *astWalker) extractRedirect(stmt *syntax.Stmt) {
-	if stmt.Redirs == nil {
-		return
-	}
+// redirInfo holds the output redirection and heredoc found on a statement.
+type redirInfo struct {
+	outputPath     string
+	outputOp       WriteOp
+	outputLoc      Location
+	heredocContent string
+	heredocLoc     Location
+	hasOutput      bool
+	hasHeredoc     bool
+}
 
-	// First pass: collect output redirections and heredocs separately
-	var outputPath string
-
-	var outputOp WriteOp
-
-	var outputLoc Location
-
-	var heredocContent string
-
-	var heredocLoc Location
-
-	hasOutput := false
-	hasHeredoc := false
+// collectRedirs gathers output redirection and heredoc details from a statement.
+func collectRedirs(stmt *syntax.Stmt) redirInfo {
+	var info redirInfo
 
 	for _, redir := range stmt.Redirs {
-		if redir.Op == syntax.RdrOut || redir.Op == syntax.AppOut {
+		switch redir.Op {
+		case syntax.RdrOut, syntax.AppOut:
 			path := wordToString(redir.Word)
 			if path == "" {
 				continue
 			}
 
-			outputPath = path
+			info.outputPath = path
 
-			outputOp = WriteOpRedirect
+			info.outputOp = WriteOpRedirect
 			if redir.Op == syntax.AppOut {
-				outputOp = WriteOpAppend
+				info.outputOp = WriteOpAppend
 			}
 
-			outputLoc = Location{
-				Line:   redir.Pos().Line(),
-				Column: redir.Pos().Col(),
-			}
-			hasOutput = true
-		}
-
-		// Handle heredocs
-		if redir.Op == syntax.Hdoc || redir.Op == syntax.DashHdoc {
-			// Extract heredoc content from Hdoc field (may be empty)
+			info.outputLoc = Location{Line: redir.Pos().Line(), Column: redir.Pos().Col()}
+			info.hasOutput = true
+		case syntax.Hdoc, syntax.DashHdoc:
+			// Extract heredoc content from Hdoc field (may be empty).
 			if redir.Hdoc != nil {
-				heredocContent = wordToString(redir.Hdoc)
+				info.heredocContent = wordToString(redir.Hdoc)
 			}
-			// Mark as heredoc even if content is empty
-			heredocLoc = Location{
-				Line:   redir.Pos().Line(),
-				Column: redir.Pos().Col(),
-			}
-			hasHeredoc = true
+			// Mark as heredoc even if content is empty.
+			info.heredocLoc = Location{Line: redir.Pos().Line(), Column: redir.Pos().Col()}
+			info.hasHeredoc = true
+		default:
+			// Other redirection operators are not relevant here.
 		}
 	}
 
-	// Second pass: create FileWrite entries
-	// If we have both output redirection and heredoc, combine them
-	if hasOutput && hasHeredoc {
-		fw := FileWrite{
-			Path:      outputPath,
-			Operation: WriteOpHeredoc,
-			Content:   heredocContent,
-			Location:  heredocLoc,
-		}
-		w.fileWrites = append(w.fileWrites, fw)
-	} else if hasOutput {
-		// Just output redirection without heredoc
-		fw := FileWrite{
-			Path:      outputPath,
-			Operation: outputOp,
-			Location:  outputLoc,
-		}
-		w.fileWrites = append(w.fileWrites, fw)
+	return info
+}
+
+// extractRedirect extracts file write operations and stdin content from redirections.
+func (w *astWalker) extractRedirect(stmt *syntax.Stmt) {
+	if stmt.Redirs == nil {
+		return
 	}
-	// Note: heredoc without output redirection is rare and not handled
-	// (it would just pipe to stdin of a command)
+
+	info := collectRedirs(stmt)
+
+	switch {
+	case info.hasOutput && info.hasHeredoc:
+		// Output redirection combined with a heredoc.
+		w.fileWrites = append(w.fileWrites, FileWrite{
+			Path:      info.outputPath,
+			Operation: WriteOpHeredoc,
+			Content:   info.heredocContent,
+			Location:  info.heredocLoc,
+		})
+	case info.hasOutput:
+		// Just output redirection without heredoc.
+		w.fileWrites = append(w.fileWrites, FileWrite{
+			Path:      info.outputPath,
+			Operation: info.outputOp,
+			Location:  info.outputLoc,
+		})
+	case info.hasHeredoc:
+		// Heredoc without output redirection feeds the command's stdin
+		// (e.g. "git commit -F - <<EOF ... EOF"). Record it so validators
+		// can inspect the message.
+		if call := callExprOf(stmt); call != nil {
+			w.recordStdin(call, info.heredocContent)
+		}
+	}
 }
 
 // extractFileWriteCommand detects file write commands (tee, cp, mv).

--- a/pkg/parser/ast_walker.go
+++ b/pkg/parser/ast_walker.go
@@ -97,23 +97,59 @@ func literalCommandOutput(call *syntax.CallExpr) (string, bool) {
 
 	switch name {
 	case "echo":
-		// Drop echo flags (-n, -e, ...); join remaining args with spaces.
-		var parts []string
-
-		for _, arg := range args {
-			if len(arg) > 0 && arg[0] == '-' {
-				continue
-			}
-
-			parts = append(parts, arg)
-		}
-
-		return strings.Join(parts, " "), true
+		return echoOutput(args), true
 	case "printf":
-		// Only handle the trivial "printf <format>" form with no directives.
-		if len(args) == 1 && !strings.Contains(args[0], "%") {
-			return args[0], true
+		return printfOutput(args)
+	}
+
+	return "", false
+}
+
+// echoOutput reproduces what "echo args..." writes to stdout. Only the leading
+// run of echo flags (-n, -e, -E and combinations) is stripped; once a non-flag
+// word appears, every remaining argument is literal, even if it starts with "-".
+func echoOutput(args []string) string {
+	i := 0
+	for i < len(args) && isEchoFlag(args[i]) {
+		i++
+	}
+
+	return strings.Join(args[i:], " ")
+}
+
+// isEchoFlag reports whether arg is an echo option like -n, -e, -E, or -ne.
+func isEchoFlag(arg string) bool {
+	if len(arg) < 2 || arg[0] != '-' {
+		return false
+	}
+
+	for _, c := range arg[1:] {
+		if c != 'n' && c != 'e' && c != 'E' {
+			return false
 		}
+	}
+
+	return true
+}
+
+// printfOutput reproduces what a simple "printf" call writes to stdout, for the
+// forms commonly used to feed a commit message: a bare literal format with no
+// directives, or "%s"/"%s\n" with a single string argument.
+func printfOutput(args []string) (string, bool) {
+	if len(args) == 0 {
+		return "", false
+	}
+
+	format := args[0]
+
+	// "printf <literal>" with no format directives.
+	if len(args) == 1 && !strings.Contains(format, "%") {
+		return format, true
+	}
+
+	// "printf %s msg" / "printf '%s\n' msg" with a single argument.
+	if len(args) == 2 && (format == "%s" || format == "%s\n" || format == `%s\n`) {
+		return args[1], true
 	}
 
 	return "", false

--- a/pkg/parser/ast_walker.go
+++ b/pkg/parser/ast_walker.go
@@ -105,14 +105,11 @@ func literalCommandOutput(call *syntax.CallExpr) (string, bool) {
 		return "", false
 	}
 
-	switch name {
-	case "echo":
+	if name == "echo" {
 		return echoOutput(args)
-	case "printf":
-		return printfOutput(args)
-	default:
-		return "", false
 	}
+
+	return printfOutput(args) // name == "printf"
 }
 
 // literalArgs converts words to strings only when every word is strictly

--- a/pkg/parser/ast_walker.go
+++ b/pkg/parser/ast_walker.go
@@ -97,7 +97,7 @@ func literalCommandOutput(call *syntax.CallExpr) (string, bool) {
 
 	switch name {
 	case "echo":
-		return echoOutput(args), true
+		return echoOutput(args)
 	case "printf":
 		return printfOutput(args)
 	}
@@ -108,28 +108,42 @@ func literalCommandOutput(call *syntax.CallExpr) (string, bool) {
 // echoOutput reproduces what "echo args..." writes to stdout. Only the leading
 // run of echo flags (-n, -e, -E and combinations) is stripped; once a non-flag
 // word appears, every remaining argument is literal, even if it starts with "-".
-func echoOutput(args []string) string {
+// It returns false when -e is present, since that enables backslash-escape
+// interpretation which this helper does not perform - capturing the raw text
+// would mis-validate the message.
+func echoOutput(args []string) (string, bool) {
 	i := 0
-	for i < len(args) && isEchoFlag(args[i]) {
+
+	for i < len(args) {
+		flag, ok := echoFlag(args[i])
+		if !ok {
+			break
+		}
+
+		if strings.ContainsRune(flag, 'e') {
+			return "", false
+		}
+
 		i++
 	}
 
-	return strings.Join(args[i:], " ")
+	return strings.Join(args[i:], " "), true
 }
 
-// isEchoFlag reports whether arg is an echo option like -n, -e, -E, or -ne.
-func isEchoFlag(arg string) bool {
+// echoFlag reports whether arg is an echo option like -n, -e, -E, or -ne and
+// returns its letters (without the leading dash) when so.
+func echoFlag(arg string) (string, bool) {
 	if len(arg) < 2 || arg[0] != '-' {
-		return false
+		return "", false
 	}
 
 	for _, c := range arg[1:] {
 		if c != 'n' && c != 'e' && c != 'E' {
-			return false
+			return "", false
 		}
 	}
 
-	return true
+	return arg[1:], true
 }
 
 // printfOutput reproduces what a simple "printf" call writes to stdout, for the

--- a/pkg/parser/ast_walker.go
+++ b/pkg/parser/ast_walker.go
@@ -92,17 +92,79 @@ func literalCommandOutput(call *syntax.CallExpr) (string, bool) {
 	}
 
 	name := wordToString(call.Args[0])
+	if name != "echo" && name != "printf" {
+		return "", false
+	}
 
-	args := wordsToStrings(call.Args[1:])
+	// Only capture when every argument is strictly literal. Expansions
+	// (parameters, command/arithmetic substitution, globs) cannot be
+	// reproduced here, so capturing would yield a message different from what
+	// the command actually emits.
+	args, ok := literalArgs(call.Args[1:])
+	if !ok {
+		return "", false
+	}
 
 	switch name {
 	case "echo":
 		return echoOutput(args)
 	case "printf":
 		return printfOutput(args)
+	default:
+		return "", false
+	}
+}
+
+// literalArgs converts words to strings only when every word is strictly
+// literal. It returns false as soon as any word contains a shell expansion.
+func literalArgs(words []*syntax.Word) ([]string, bool) {
+	args := make([]string, 0, len(words))
+
+	for _, word := range words {
+		if !isLiteralWord(word) {
+			return nil, false
+		}
+
+		args = append(args, wordToString(word))
 	}
 
-	return "", false
+	return args, true
+}
+
+// isLiteralWord reports whether a word consists solely of literal text - plain
+// literals and single/double-quoted literals - with no shell expansions such as
+// parameters, command/arithmetic substitution, or globbing.
+func isLiteralWord(word *syntax.Word) bool {
+	if word == nil {
+		return false
+	}
+
+	for _, part := range word.Parts {
+		switch p := part.(type) {
+		case *syntax.Lit, *syntax.SglQuoted:
+			// Literal text, no expansion.
+		case *syntax.DblQuoted:
+			if !allLiteralParts(p.Parts) {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+
+	return true
+}
+
+// allLiteralParts reports whether every part is a plain literal (no expansions),
+// as found inside a double-quoted string.
+func allLiteralParts(parts []syntax.WordPart) bool {
+	for _, p := range parts {
+		if _, ok := p.(*syntax.Lit); !ok {
+			return false
+		}
+	}
+
+	return true
 }
 
 // echoOutput reproduces what "echo args..." writes to stdout. Only the leading

--- a/pkg/parser/ast_walker.go
+++ b/pkg/parser/ast_walker.go
@@ -255,6 +255,15 @@ func (w *astWalker) extractRedirect(stmt *syntax.Stmt) {
 
 	info := collectRedirs(stmt)
 
+	// A heredoc always feeds the command's stdin, regardless of any output
+	// redirection on the same statement. Record it so validators can inspect
+	// stdin-fed content (e.g. "git commit -F - <<EOF ... EOF >/dev/null").
+	if info.hasHeredoc {
+		if call := callExprOf(stmt); call != nil {
+			w.recordStdin(call, info.heredocContent)
+		}
+	}
+
 	switch {
 	case info.hasOutput && info.hasHeredoc:
 		// Output redirection combined with a heredoc.
@@ -271,13 +280,6 @@ func (w *astWalker) extractRedirect(stmt *syntax.Stmt) {
 			Operation: info.outputOp,
 			Location:  info.outputLoc,
 		})
-	case info.hasHeredoc:
-		// Heredoc without output redirection feeds the command's stdin
-		// (e.g. "git commit -F - <<EOF ... EOF"). Record it so validators
-		// can inspect the message.
-		if call := callExprOf(stmt); call != nil {
-			w.recordStdin(call, info.heredocContent)
-		}
 	}
 }
 

--- a/pkg/parser/ast_walker.go
+++ b/pkg/parser/ast_walker.go
@@ -164,12 +164,14 @@ func allLiteralParts(parts []syntax.WordPart) bool {
 	return true
 }
 
-// echoOutput reproduces what "echo args..." writes to stdout. Only the leading
-// run of echo flags (-n, -e, -E and combinations) is stripped; once a non-flag
-// word appears, every remaining argument is literal, even if it starts with "-".
-// It returns false when -e is present, since that enables backslash-escape
-// interpretation which this helper does not perform - capturing the raw text
-// would mis-validate the message.
+// echoOutput returns the literal text content of an "echo args..." call. Only
+// the leading run of echo flags (-n, -e, -E and combinations) is stripped; once
+// a non-flag word appears, every remaining argument is literal, even if it
+// starts with "-". It returns false when -e is present, since that enables
+// backslash-escape interpretation which this helper does not perform - capturing
+// the raw text would mis-validate the message. This is a best-effort capture for
+// validation: it joins the arguments with spaces and omits the trailing newline
+// echo would normally emit (callers trim surrounding whitespace anyway).
 func echoOutput(args []string) (string, bool) {
 	i := 0
 
@@ -205,9 +207,12 @@ func echoFlag(arg string) (string, bool) {
 	return arg[1:], true
 }
 
-// printfOutput reproduces what a simple "printf" call writes to stdout, for the
-// forms commonly used to feed a commit message: a bare literal format with no
-// directives, or "%s"/"%s\n" with a single string argument.
+// printfOutput returns the literal text content of a simple "printf" call, for
+// the forms commonly used to feed a commit message: a bare literal format with
+// no directives, or "%s"/"%s\n" with a single string argument. This is a
+// best-effort capture for validation: it returns the argument text itself and
+// does not apply any newline implied by the format string (callers trim
+// surrounding whitespace anyway).
 func printfOutput(args []string) (string, bool) {
 	if len(args) == 0 {
 		return "", false

--- a/pkg/parser/ast_walker_internal_test.go
+++ b/pkg/parser/ast_walker_internal_test.go
@@ -1,0 +1,29 @@
+package parser
+
+import (
+	"testing"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// These cover defensive guards that are unreachable through normal parsing
+// (a CallExpr always has a name, a statement always has a command) but are kept
+// for safety.
+
+func TestCallExprOfNilStatement(t *testing.T) {
+	if got := callExprOf(nil); got != nil {
+		t.Fatalf("callExprOf(nil) = %v, want nil", got)
+	}
+}
+
+func TestLiteralCommandOutputNoArgs(t *testing.T) {
+	if _, ok := literalCommandOutput(&syntax.CallExpr{}); ok {
+		t.Fatal("literalCommandOutput with no args should not be capturable")
+	}
+}
+
+func TestIsLiteralWordNil(t *testing.T) {
+	if isLiteralWord(nil) {
+		t.Fatal("isLiteralWord(nil) = true, want false")
+	}
+}

--- a/pkg/parser/bash_test.go
+++ b/pkg/parser/bash_test.go
@@ -329,6 +329,102 @@ EOF`
 		})
 	})
 
+	Describe("stdin capture", func() {
+		// gitStdin parses cmd and returns the Stdin captured for the git command.
+		gitStdin := func(cmd string) string {
+			result, err := p.Parse(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, c := range result.Commands {
+				if c.Name == "git" {
+					return c.Stdin
+				}
+			}
+
+			Fail("no git command found in: " + cmd)
+
+			return ""
+		}
+
+		Context("heredoc", func() {
+			It("records heredoc content as stdin", func() {
+				cmd := "git commit -F - <<'EOF'\nfix(x): message\nEOF"
+				Expect(gitStdin(cmd)).To(Equal("fix(x): message\n"))
+			})
+
+			It("records heredoc stdin even with an output redirect", func() {
+				cmd := "git commit -F - <<'EOF' >/dev/null\nfix(x): message\nEOF"
+				Expect(gitStdin(cmd)).To(Equal("fix(x): message\n"))
+			})
+		})
+
+		Context("piped producers", func() {
+			It("captures echo output", func() {
+				Expect(gitStdin(`echo "fix(x): message" | git commit -F -`)).
+					To(Equal("fix(x): message"))
+			})
+
+			It("strips only the leading -n/-e/-E flag run from echo", func() {
+				Expect(gitStdin(`echo -n "fix(x): message" | git commit -F -`)).
+					To(Equal("fix(x): message"))
+			})
+
+			It("keeps dash-prefixed words that are not leading flags", func() {
+				Expect(gitStdin(`echo "fix(x):" handle -dash words | git commit -F -`)).
+					To(Equal("fix(x): handle -dash words"))
+			})
+
+			It("does not capture echo -e (escape interpretation)", func() {
+				Expect(gitStdin(`echo -e "fix(x): message" | git commit -F -`)).
+					To(BeEmpty())
+			})
+
+			It("captures printf with a bare literal format", func() {
+				Expect(gitStdin(`printf "fix(x): message" | git commit -F -`)).
+					To(Equal("fix(x): message"))
+			})
+
+			It("captures printf %s with a single argument", func() {
+				Expect(gitStdin(`printf '%s' "fix(x): message" | git commit -F -`)).
+					To(Equal("fix(x): message"))
+			})
+
+			It("captures printf %s\\n with a single argument", func() {
+				Expect(gitStdin(`printf '%s\n' "fix(x): message" | git commit -F -`)).
+					To(Equal("fix(x): message"))
+			})
+
+			It("does not capture printf with unsupported directives", func() {
+				Expect(gitStdin(`printf '%d' 42 | git commit -F -`)).To(BeEmpty())
+			})
+
+			It("does not capture output containing a parameter expansion", func() {
+				Expect(gitStdin(`echo "fix(x): $VAR" | git commit -F -`)).To(BeEmpty())
+			})
+
+			It("does not capture an unquoted parameter expansion", func() {
+				Expect(gitStdin(`echo $VAR | git commit -F -`)).To(BeEmpty())
+			})
+
+			It("treats an unknown dash option as literal echo text", func() {
+				Expect(gitStdin(`echo -x "fix(x): message" | git commit -F -`)).
+					To(Equal("-x fix(x): message"))
+			})
+
+			It("captures empty stdin from a flagless printf", func() {
+				Expect(gitStdin(`printf | git commit -F -`)).To(BeEmpty())
+			})
+
+			It("does not capture output containing a command substitution", func() {
+				Expect(gitStdin("echo \"fix(x): $(date)\" | git commit -F -")).To(BeEmpty())
+			})
+
+			It("does not capture non-echo/printf producers", func() {
+				Expect(gitStdin(`cat msg.txt | git commit -F -`)).To(BeEmpty())
+			})
+		})
+	})
+
 	Describe("ParseResult methods", func() {
 		It("HasCommand checks command existence", func() {
 			result, err := p.Parse("git status && echo done")

--- a/pkg/parser/command.go
+++ b/pkg/parser/command.go
@@ -56,6 +56,7 @@ type Command struct {
 	Type             CmdType  // Command type
 	Raw              string   // Raw command string
 	WorkingDirectory string   // Effective working directory from preceding cd commands
+	Stdin            string   // Content fed to stdin via heredoc or a piped echo/printf
 }
 
 // String returns a string representation of the command.

--- a/pkg/parser/git.go
+++ b/pkg/parser/git.go
@@ -21,6 +21,7 @@ type GitCommand struct {
 	FlagMap          map[string]string // Flag values (e.g., "-m" -> "commit message")
 	GlobalOptions    map[string]string // Global git options (e.g., "-C" -> "/path/to/repo")
 	WorkingDirectory string            // Working directory from preceding cd commands
+	Stdin            string            // Content fed to stdin (heredoc or piped echo/printf)
 }
 
 // Global git options that take a value.
@@ -77,6 +78,7 @@ func ParseGitCommand(cmd Command) (*GitCommand, error) {
 		FlagMap:          make(map[string]string),
 		GlobalOptions:    make(map[string]string),
 		WorkingDirectory: cmd.WorkingDirectory,
+		Stdin:            cmd.Stdin,
 	}
 
 	// First, parse global options and find the subcommand


### PR DESCRIPTION
## Motivation

Running `git commit -F -` reads the commit message from stdin. The commit validator treated `-` as a literal filename and tried to `os.ReadFile("-")`, which failed with:

```
Failed to read commit message: failed to read commit message file -: open -: no such file or directory
```

Beyond the noisy warning, the message was never validated at all - so a non-conventional commit title fed through `-F -` slipped past the hook.

## Implementation information

- Added a `Stdin` field to `parser.Command` and `parser.GitCommand`.
- The bash AST walker now captures stdin content fed two ways:
  - a heredoc with no output redirect (`git commit -F - <<'EOF' ... EOF`)
  - a piped `echo` or simple `printf` (`echo "msg" | git commit -F -`)
- When the `-F`/`--file` value is `-`, the commit validator validates the captured stdin instead of trying to open a file.
- A bare `-F -` with no capturable stdin passes cleanly (message assumed to come from the editor), instead of warning.

Refactored `extractRedirect` into a `collectRedirs` helper to keep cognitive complexity within limits.

Added test cases covering heredoc (valid/invalid), pipe, and the no-stdin case.