### PR TITLE
fix(git): validate variable-path commit messages

### DIFF
--- a/internal/validators/git/branch.go
+++ b/internal/validators/git/branch.go
@@ -208,6 +208,16 @@ func (v *BranchValidator) validateBranchCreation(gitCmd *parser.GitCommand) *val
 		return nil
 	}
 
+	// A bare variable branch name (e.g. "git checkout -b $BRANCH") is an
+	// unresolved expansion whose runtime value the hook cannot see, so its
+	// format can't be checked. Skip rather than block.
+	if isBareExpansion(branchName) {
+		v.Logger().
+			Debug("branch name is an unresolved variable; skipping validation", "branch", branchName)
+
+		return nil
+	}
+
 	if strings.Contains(branchName, " ") {
 		return v.createSpaceError()
 	}

--- a/internal/validators/git/branch_test.go
+++ b/internal/validators/git/branch_test.go
@@ -73,6 +73,16 @@ var _ = Describe("BranchValidator", func() {
 			})
 		})
 
+		Context("with a bare variable branch name", func() {
+			It("skips validation for an unresolved variable", func() {
+				// "$BRANCH" is an unresolved expansion; the hook cannot see its
+				// runtime value, so its format must not be validated.
+				ctx.ToolInput.Command = `git checkout -b "$BRANCH"`
+				result := v.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeTrue())
+			})
+		})
+
 		Context("with protected branches", func() {
 			It("should skip validation for main", func() {
 				ctx.ToolInput.Command = "git checkout -b main"

--- a/internal/validators/git/commit.go
+++ b/internal/validators/git/commit.go
@@ -427,12 +427,13 @@ func expandTilde(path string) string {
 }
 
 // isBareExpansion reports whether s is exactly one shell parameter expansion as
-// rendered by the parser - "$NAME" or "${...}" - and nothing else. Such a value
-// is an unresolved variable whose runtime content the hook cannot observe, so
-// callers skip validation instead of treating the literal token as the message
-// or as a real file path. A literal "$NAME" written in single quotes renders the
-// same way, but committing a literal "$NAME" message or reading a file literally
-// named "$NAME" is not a realistic scenario, so skipping it is acceptable.
+// rendered by the parser - "$NAME", a positional like "$1", a special parameter
+// like "$@"/"$?", or "${...}" - and nothing else. Such a value is an unresolved
+// expansion whose runtime content the hook cannot observe, so callers skip
+// validation instead of treating the literal token as the message or as a real
+// file path. A literal "$NAME" written in single quotes renders the same way,
+// but committing a literal "$NAME" message or reading a file literally named
+// "$NAME" is not a realistic scenario, so skipping it is acceptable.
 func isBareExpansion(s string) bool {
 	if len(s) < 2 || s[0] != '$' {
 		return false
@@ -444,7 +445,13 @@ func isBareExpansion(s string) bool {
 		return len(body) > 2 && body[len(body)-1] == '}'
 	}
 
-	// "$NAME": every remaining byte must be a valid identifier character.
+	// A single special parameter: $@, $*, $#, $?, $$, $!, $- (e.g. a wrapper
+	// script forwarding "$@" to git push).
+	if len(body) == 1 && isSpecialParam(body[0]) {
+		return true
+	}
+
+	// "$NAME" or a positional like "$12": every byte is an identifier character.
 	for i := range len(body) {
 		if !isNameByte(body[i]) {
 			return false
@@ -460,6 +467,17 @@ func isNameByte(b byte) bool {
 		(b >= 'a' && b <= 'z') ||
 		(b >= 'A' && b <= 'Z') ||
 		(b >= '0' && b <= '9')
+}
+
+// isSpecialParam reports whether b is a single-character shell special
+// parameter ($@, $*, $#, $?, $$, $!, $-).
+func isSpecialParam(b byte) bool {
+	switch b {
+	case '@', '*', '#', '?', '$', '!', '-':
+		return true
+	default:
+		return false
+	}
 }
 
 // getFlagValue returns the value for any of the provided flags, or empty string if not found.

--- a/internal/validators/git/commit.go
+++ b/internal/validators/git/commit.go
@@ -311,6 +311,16 @@ func (v *CommitValidator) extractCommitMessage(
 	// Check for inline message flags (-m/--message)
 	// TrimSpace handles trailing newlines from HEREDOC syntax: -m "$(cat <<'EOF'\n...\nEOF\n)"
 	if msg := v.getFlagValue(gitCmd, commitMessageFlags); msg != "" {
+		// A bare variable (e.g. -m "$MSG") is an unresolved expansion whose
+		// runtime content the hook cannot see. Skip rather than validate the
+		// literal token, which would always fail the conventional-commit check.
+		if isBareExpansion(msg) {
+			v.Logger().
+				Debug("commit message is an unresolved variable; skipping validation", "value", msg)
+
+			return "", nil
+		}
+
 		return strings.TrimSpace(msg), nil
 	}
 
@@ -360,6 +370,16 @@ func (v *CommitValidator) extractMessageFromFile(
 		}
 	}
 
+	// A bare variable path (e.g. -F "$MSG") that did not resolve to inline
+	// content names a file whose runtime location the hook cannot determine.
+	// Skip rather than attempt a literal "$MSG" disk read that always fails.
+	if isBareExpansion(filePath) {
+		v.Logger().
+			Debug("commit message file path is an unresolved variable; skipping validation", "path", filePath)
+
+		return "", nil
+	}
+
 	// Resolve the path the way the shell would: expand a leading ~ and, for a
 	// relative path, join it onto the commit's effective working directory (from
 	// cd or git -C), since git reads -F relative to where it runs, not the hook's
@@ -404,6 +424,42 @@ func expandTilde(path string) string {
 	}
 
 	return filepath.Join(home, path[2:])
+}
+
+// isBareExpansion reports whether s is exactly one shell parameter expansion as
+// rendered by the parser - "$NAME" or "${...}" - and nothing else. Such a value
+// is an unresolved variable whose runtime content the hook cannot observe, so
+// callers skip validation instead of treating the literal token as the message
+// or as a real file path. A literal "$NAME" written in single quotes renders the
+// same way, but committing a literal "$NAME" message or reading a file literally
+// named "$NAME" is not a realistic scenario, so skipping it is acceptable.
+func isBareExpansion(s string) bool {
+	if len(s) < 2 || s[0] != '$' {
+		return false
+	}
+
+	body := s[1:]
+	if body[0] == '{' {
+		// "${...}": require a closing brace and a non-empty body.
+		return len(body) > 2 && body[len(body)-1] == '}'
+	}
+
+	// "$NAME": every remaining byte must be a valid identifier character.
+	for i := range len(body) {
+		if !isNameByte(body[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// isNameByte reports whether b may appear in a shell variable name.
+func isNameByte(b byte) bool {
+	return b == '_' ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9')
 }
 
 // getFlagValue returns the value for any of the provided flags, or empty string if not found.

--- a/internal/validators/git/commit.go
+++ b/internal/validators/git/commit.go
@@ -427,57 +427,21 @@ func expandTilde(path string) string {
 }
 
 // isBareExpansion reports whether s is exactly one shell parameter expansion as
-// rendered by the parser - "$NAME", a positional like "$1", a special parameter
-// like "$@"/"$?", or "${...}" - and nothing else. Such a value is an unresolved
-// expansion whose runtime content the hook cannot observe, so callers skip
-// validation instead of treating the literal token as the message or as a real
-// file path. A literal "$NAME" written in single quotes renders the same way,
-// but committing a literal "$NAME" message or reading a file literally named
-// "$NAME" is not a realistic scenario, so skipping it is acceptable.
+// rendered by the parser - the braced token "${...}" produced by
+// paramExpToString - and nothing else. Such a value is an unresolved variable
+// whose runtime content the hook cannot observe, so callers skip validation
+// instead of treating the token as a real message, file path, remote, or branch.
+// A single-quoted literal that merely looks like a variable (e.g. '$MSG') renders
+// without braces and is still validated; a value mixing an expansion with literal
+// text (e.g. "${1}foo") does not end in "}" and is likewise not skipped.
 func isBareExpansion(s string) bool {
-	if len(s) < 2 || s[0] != '$' {
+	if len(s) < 4 || s[0] != '$' || s[1] != '{' || s[len(s)-1] != '}' {
 		return false
 	}
 
-	body := s[1:]
-	if body[0] == '{' {
-		// "${...}": require a closing brace and a non-empty body.
-		return len(body) > 2 && body[len(body)-1] == '}'
-	}
+	inner := s[2 : len(s)-1]
 
-	// A single special parameter: $@, $*, $#, $?, $$, $!, $- (e.g. a wrapper
-	// script forwarding "$@" to git push).
-	if len(body) == 1 && isSpecialParam(body[0]) {
-		return true
-	}
-
-	// "$NAME" or a positional like "$12": every byte is an identifier character.
-	for i := range len(body) {
-		if !isNameByte(body[i]) {
-			return false
-		}
-	}
-
-	return true
-}
-
-// isNameByte reports whether b may appear in a shell variable name.
-func isNameByte(b byte) bool {
-	return b == '_' ||
-		(b >= 'a' && b <= 'z') ||
-		(b >= 'A' && b <= 'Z') ||
-		(b >= '0' && b <= '9')
-}
-
-// isSpecialParam reports whether b is a single-character shell special
-// parameter ($@, $*, $#, $?, $$, $!, $-).
-func isSpecialParam(b byte) bool {
-	switch b {
-	case '@', '*', '#', '?', '$', '!', '-':
-		return true
-	default:
-		return false
-	}
+	return inner != "" && !strings.ContainsAny(inner, "{}")
 }
 
 // getFlagValue returns the value for any of the provided flags, or empty string if not found.

--- a/internal/validators/git/commit_test.go
+++ b/internal/validators/git/commit_test.go
@@ -1498,7 +1498,7 @@ Signed-off-by: Test User <test@klaudiu.sh>`
 		It("validates a printf-written message at a variable path (good)", func() {
 			// Screenshot case: a multi-line message is built with printf and
 			// referenced through a variable. Both the redirect target and the -F
-			// path render to "$MSG", so the captured content is validated.
+			// path render to "${MSG}", so the captured content is validated.
 			cmd := `printf '%s\n\n%s\n' 'feat(api): add endpoint' 'Adds the endpoint.' > "$MSG" && ` +
 				`git commit -sS -a -F "$MSG"`
 
@@ -1609,6 +1609,19 @@ Signed-off-by: Test User <test@klaudiu.sh>`
 			result := validator.Validate(context.Background(), ctx)
 			Expect(result.Passed).To(BeFalse())
 			Expect(result.ShouldBlock).To(BeTrue())
+		})
+
+		It("skips a modified -m expansion", func() {
+			// "${MSG:-default}" is still an unresolved expansion (its value depends
+			// on MSG at runtime), so it is skipped rather than validated.
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{Command: `git commit -sS -a -m "${MSG:-default}"`},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeTrue())
 		})
 
 		It("skips an unresolved -F variable path with no inline write", func() {

--- a/internal/validators/git/commit_test.go
+++ b/internal/validators/git/commit_test.go
@@ -1550,6 +1550,26 @@ Signed-off-by: Test User <test@klaudiu.sh>`
 			).ToNot(ContainSubstring("failed to read commit message file"))
 		})
 
+		It("matches a $VAR redirect against a ${VAR} -F path", func() {
+			// The redirect and the -F flag name the same variable in different
+			// forms; both canonicalize to one token, so the message is validated.
+			cmd := `printf '%s\n\n%s\n' 'not conventional' 'body' > "$MSG" && ` +
+				`git commit -sS -a -F "${MSG}"`
+
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{Command: cmd},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeFalse())
+			Expect(result.ShouldBlock).To(BeTrue())
+			Expect(
+				result.Message,
+			).To(ContainSubstring("doesn't follow conventional commits format"))
+		})
+
 		It("skips an unresolved -m variable instead of validating the token", func() {
 			// The hook cannot see $VAR's runtime value, so it must not validate
 			// the literal "$VAR" (which would fail the conventional-commit check).

--- a/internal/validators/git/commit_test.go
+++ b/internal/validators/git/commit_test.go
@@ -1474,9 +1474,10 @@ Signed-off-by: Test User <test@klaudiu.sh>`
 			Expect(result.Message).To(ContainSubstring("Failed to read commit message"))
 		})
 
-		It("falls back to disk (warns) for an uncaptured echo redirect", func() {
-			// Plain redirects aren't captured, so the validator reads the file
-			// from disk; at PreToolUse it does not exist yet, hence a warning.
+		It("validates a message written via an echo redirect", func() {
+			// A literal echo overwrite is captured for message recovery, so the
+			// validator sees the non-conventional message and blocks even though
+			// the file does not exist on disk yet.
 			cmd := `echo 'this is not conventional' > /nonexistent/dir/msg.txt && ` +
 				`git commit -sS -a -F /nonexistent/dir/msg.txt`
 
@@ -1488,8 +1489,91 @@ Signed-off-by: Test User <test@klaudiu.sh>`
 
 			result := validator.Validate(context.Background(), ctx)
 			Expect(result.Passed).To(BeFalse())
-			Expect(result.ShouldBlock).To(BeFalse())
-			Expect(result.Message).To(ContainSubstring("Failed to read commit message"))
+			Expect(result.ShouldBlock).To(BeTrue())
+			Expect(
+				result.Message,
+			).To(ContainSubstring("doesn't follow conventional commits format"))
+		})
+
+		It("validates a printf-written message at a variable path (good)", func() {
+			// Screenshot case: a multi-line message is built with printf and
+			// referenced through a variable. Both the redirect target and the -F
+			// path render to "$MSG", so the captured content is validated.
+			cmd := `printf '%s\n\n%s\n' 'feat(api): add endpoint' 'Adds the endpoint.' > "$MSG" && ` +
+				`git commit -sS -a -F "$MSG"`
+
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{Command: cmd},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeTrue())
+		})
+
+		It("blocks a printf-written message at a variable path (bad)", func() {
+			cmd := `printf '%s\n\n%s\n' 'not conventional' 'body' > "$MSG" && ` +
+				`git commit -sS -a -F "$MSG"`
+
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{Command: cmd},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeFalse())
+			Expect(result.ShouldBlock).To(BeTrue())
+			Expect(
+				result.Message,
+			).To(ContainSubstring("doesn't follow conventional commits format"))
+		})
+
+		It("does not misread -- as the message file with a variable -F path", func() {
+			// Regression: "$MSG" once rendered empty and was dropped, so -F
+			// captured the "--" separator and the validator reported "failed to
+			// read commit message file --". It must validate the message instead.
+			cmd := `printf '%s' 'feat(api): add endpoint' > "$MSG" && ` +
+				`git commit -sS -a -F "$MSG" -- file.go`
+
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{Command: cmd},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeTrue())
+			Expect(
+				result.Message,
+			).ToNot(ContainSubstring("failed to read commit message file"))
+		})
+
+		It("skips an unresolved -m variable instead of validating the token", func() {
+			// The hook cannot see $VAR's runtime value, so it must not validate
+			// the literal "$VAR" (which would fail the conventional-commit check).
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{Command: `git commit -sS -a -m "$VAR"`},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeTrue())
+		})
+
+		It("skips an unresolved -F variable path with no inline write", func() {
+			// "$MSG" was never written in this command, so there is nothing to
+			// recover and no real path to read. Skip rather than warn.
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{Command: `git commit -sS -a -F "$MSG"`},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeTrue())
 		})
 	})
 

--- a/internal/validators/git/commit_test.go
+++ b/internal/validators/git/commit_test.go
@@ -1583,6 +1583,34 @@ Signed-off-by: Test User <test@klaudiu.sh>`
 			Expect(result.Passed).To(BeTrue())
 		})
 
+		It("validates a single-quoted literal that looks like a variable", func() {
+			// '$MSG' is a literal, not an expansion, so it renders without braces
+			// and must be validated (and rejected) rather than skipped.
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{Command: `git commit -sS -a -m '$MSG'`},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeFalse())
+			Expect(result.ShouldBlock).To(BeTrue())
+		})
+
+		It("validates a value mixing an expansion with literal text", func() {
+			// "$9FOO" is positional $9 plus literal FOO, not a single expansion,
+			// so it renders as "${9}FOO" and is not skipped.
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{Command: `git commit -sS -a -m "$9FOO"`},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeFalse())
+			Expect(result.ShouldBlock).To(BeTrue())
+		})
+
 		It("skips an unresolved -F variable path with no inline write", func() {
 			// "$MSG" was never written in this command, so there is nothing to
 			// recover and no real path to read. Skip rather than warn.

--- a/internal/validators/git/push.go
+++ b/internal/validators/git/push.go
@@ -84,6 +84,15 @@ func (v *PushValidator) validatePushCommand(
 		return validator.Pass()
 	}
 
+	// A bare variable remote (e.g. "git push $REMOTE main") is an unresolved
+	// expansion whose runtime value the hook cannot see, so neither the blocked
+	// list nor existence can be checked meaningfully. Skip rather than block.
+	if isBareExpansion(remote) {
+		log.Debug("remote is an unresolved variable; skipping validation", "remote", remote)
+
+		return validator.Pass()
+	}
+
 	// Check if remote is blocked (before checking if it exists)
 	if result := v.validateNotBlockedRemote(remote, runner); !result.Passed {
 		return result

--- a/internal/validators/git/push_test.go
+++ b/internal/validators/git/push_test.go
@@ -95,6 +95,14 @@ var _ = Describe("PushValidator", func() {
 				Expect(result.Passed).To(BeTrue())
 			})
 
+			It("skips validation for a forwarded \"$@\" remote", func() {
+				// Wrapper scripts call "git push $@"; the special parameter is an
+				// unresolved expansion, so it must not be validated as a remote.
+				ctx := createContext(`git push "$@"`)
+				result := validator.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeTrue())
+			})
+
 			It("extracts remote from various push formats", func() {
 				testCases := []struct {
 					command     string

--- a/internal/validators/git/push_test.go
+++ b/internal/validators/git/push_test.go
@@ -87,6 +87,14 @@ var _ = Describe("PushValidator", func() {
 				Expect(result.Message).To(ContainSubstring("upstream"))
 			})
 
+			It("skips validation for a bare variable remote", func() {
+				// "$REMOTE" is an unresolved expansion; the validator cannot check
+				// whether it exists or is blocked, so it must not block the push.
+				ctx := createContext("git push $REMOTE $BRANCH")
+				result := validator.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeTrue())
+			})
+
 			It("extracts remote from various push formats", func() {
 				testCases := []struct {
 					command     string

--- a/pkg/parser/ast_walker.go
+++ b/pkg/parser/ast_walker.go
@@ -207,30 +207,122 @@ func echoFlag(arg string) (string, bool) {
 	return arg[1:], true
 }
 
-// printfOutput returns the literal text content of a simple "printf" call, for
-// the forms commonly used to feed a commit message: a bare literal format with
-// no directives, or "%s"/"%s\n" with a single string argument. This is a
-// best-effort capture for validation: it returns the argument text itself and
-// does not apply any newline implied by the format string (callers trim
-// surrounding whitespace anyway).
+// printfOutput returns the text a simple "printf" call writes, for the forms
+// used to build commit messages: a bare literal format, or a format whose only
+// directives are %s (one string argument each) and %%. Backslash escapes in the
+// format (\n, \t, \r, \\, \a, \b, \f, \v) are interpreted, so a multi-line
+// message like "printf '%s\n\n%s\n' title body" is reconstructed correctly. A
+// single trailing newline is dropped (callers trim surrounding whitespace
+// anyway). It returns false for any other directive (e.g. %d, %q), an unknown
+// escape, or a %s/argument count mismatch, so an uncertain capture falls back to
+// a disk read rather than validating reconstructed-wrong bytes.
 func printfOutput(args []string) (string, bool) {
 	if len(args) == 0 {
 		return "", false
 	}
 
-	format := args[0]
-
-	// "printf <literal>" with no format directives.
-	if len(args) == 1 && !strings.Contains(format, "%") {
-		return format, true
+	out, ok := expandPrintf(args[0], args[1:])
+	if !ok {
+		return "", false
 	}
 
-	// "printf %s msg" / "printf '%s\n' msg" with a single argument.
-	if len(args) == 2 && (format == "%s" || format == "%s\n" || format == `%s\n`) {
-		return args[1], true
+	return strings.TrimSuffix(out, "\n"), true
+}
+
+// expandPrintf reproduces a printf call's output for formats that use only %s
+// and %% directives plus known backslash escapes. It returns false when the
+// format contains any other directive, an unknown or trailing escape, a dangling
+// "%", or when the number of %s directives does not equal len(args) - printf's
+// format recycling and missing-argument behaviour are intentionally not
+// reproduced, so such calls decline capture instead of guessing.
+func expandPrintf(format string, args []string) (string, bool) {
+	var b strings.Builder
+
+	used := 0
+
+	for i := 0; i < len(format); i++ {
+		switch format[i] {
+		case '\\':
+			i++
+			if i >= len(format) {
+				return "", false
+			}
+
+			esc, ok := printfEscape(format[i])
+			if !ok {
+				return "", false
+			}
+
+			b.WriteByte(esc)
+		case '%':
+			i++
+			if i >= len(format) {
+				return "", false
+			}
+
+			ok := writePrintfVerb(&b, format[i], args, &used)
+			if !ok {
+				return "", false
+			}
+		default:
+			b.WriteByte(format[i])
+		}
 	}
 
-	return "", false
+	if used != len(args) {
+		return "", false
+	}
+
+	return b.String(), true
+}
+
+// writePrintfVerb handles the character after a "%" in a printf format. It
+// supports "%%" (a literal percent) and "%s" (consuming the next argument),
+// returning false for any other verb or when no argument remains for "%s".
+func writePrintfVerb(b *strings.Builder, verb byte, args []string, used *int) bool {
+	switch verb {
+	case '%':
+		b.WriteByte('%')
+
+		return true
+	case 's':
+		if *used >= len(args) {
+			return false
+		}
+
+		b.WriteString(args[*used])
+		*used++
+
+		return true
+	default:
+		return false
+	}
+}
+
+// printfEscape interprets a backslash escape in a printf format string. It
+// returns false for escapes this best-effort reproducer does not handle (e.g.
+// octal or hex), so the caller can decline to capture rather than guess.
+func printfEscape(c byte) (byte, bool) {
+	switch c {
+	case 'n':
+		return '\n', true
+	case 't':
+		return '\t', true
+	case 'r':
+		return '\r', true
+	case '\\':
+		return '\\', true
+	case 'a':
+		return '\a', true
+	case 'b':
+		return '\b', true
+	case 'f':
+		return '\f', true
+	case 'v':
+		return '\v', true
+	default:
+		return 0, false
+	}
 }
 
 // extractCommand extracts a command from a CallExpr node.
@@ -359,16 +451,27 @@ func (w *astWalker) extractRedirect(stmt *syntax.Stmt) {
 			WorkingDirectory: w.currentDir,
 		})
 	case info.hasOutput:
-		// Just output redirection without heredoc. Content is intentionally not
-		// captured here: it would flow to the dispatcher's synthetic file-write
-		// validation and lint partial bytes (e.g. "echo 'x' > foo.go" tripping
-		// gofumpt). Heredoc bodies are the only redirect content captured.
-		w.fileWrites = append(w.fileWrites, FileWrite{
+		// Just output redirection without heredoc. A literal overwrite's output
+		// is captured into RedirectContent for inline commit-message recovery
+		// (e.g. printf '%s' msg > "$MSG"; git commit -F "$MSG"), but never into
+		// Content: Content flows to the dispatcher's synthetic file-write
+		// validation, which would lint partial bytes (e.g. "echo 'x' > foo.go"
+		// tripping gofumpt).
+		fw := FileWrite{
 			Path:             info.outputPath,
 			Operation:        info.outputOp,
 			Location:         info.outputLoc,
 			WorkingDirectory: w.currentDir,
-		})
+		}
+
+		if info.outputOp == WriteOpRedirect {
+			if content, ok := literalCommandOutput(callExprOf(stmt)); ok {
+				fw.RedirectContent = content
+				fw.RedirectContentCaptured = true
+			}
+		}
+
+		w.fileWrites = append(w.fileWrites, fw)
 	}
 }
 

--- a/pkg/parser/ast_walker.go
+++ b/pkg/parser/ast_walker.go
@@ -87,7 +87,10 @@ func callExprOf(stmt *syntax.Stmt) *syntax.CallExpr {
 // literalCommandOutput returns the text a simple echo/printf command writes to
 // stdout, when it can be determined from literal arguments alone.
 func literalCommandOutput(call *syntax.CallExpr) (string, bool) {
-	if len(call.Args) == 0 {
+	// callExprOf returns nil for statements that are not a simple command (e.g.
+	// a redirected block or subshell like "{ echo hi; } > out"), so guard
+	// against a nil call to avoid a panic.
+	if call == nil || len(call.Args) == 0 {
 		return "", false
 	}
 

--- a/pkg/parser/ast_walker_internal_test.go
+++ b/pkg/parser/ast_walker_internal_test.go
@@ -27,3 +27,50 @@ func TestIsLiteralWordNil(t *testing.T) {
 		t.Fatal("isLiteralWord(nil) = true, want false")
 	}
 }
+
+func TestParamExpToStringNil(t *testing.T) {
+	if got := paramExpToString(nil); got != "" {
+		t.Fatalf("paramExpToString(nil) = %q, want empty", got)
+	}
+}
+
+func TestPrintfOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+		ok   bool
+	}{
+		{"no args", nil, "", false},
+		{"bare literal", []string{"fix: x"}, "fix: x", true},
+		{"single %s", []string{"%s", "fix: x"}, "fix: x", true},
+		{"%s with trailing newline trimmed", []string{`%s\n`, "fix: x"}, "fix: x", true},
+		{
+			"multi %s keeps the blank line",
+			[]string{`%s\n\n%s\n`, "title", "body"},
+			"title\n\nbody",
+			true,
+		},
+		{"literal percent", []string{`100%% done`}, "100% done", true},
+		{"tab escape", []string{`a\tb`}, "a\tb", true},
+		{"unsupported directive", []string{"%d", "42"}, "", false},
+		{"too many args (recycling declined)", []string{`%s\n`, "a", "b"}, "", false},
+		{"too few args", []string{"%s %s", "a"}, "", false},
+		{"dangling percent", []string{"done%"}, "", false},
+		{"unknown escape", []string{`a\x41`}, "", false},
+		{"trailing backslash", []string{`a\`}, "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := printfOutput(tt.args)
+			if ok != tt.ok {
+				t.Fatalf("printfOutput(%q) ok = %v, want %v", tt.args, ok, tt.ok)
+			}
+
+			if got != tt.want {
+				t.Fatalf("printfOutput(%q) = %q, want %q", tt.args, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/parser/bash.go
+++ b/pkg/parser/bash.go
@@ -151,9 +151,11 @@ func (r *ParseResult) InlineFileContent(path, workDir string, before Location) (
 
 		switch fw.Operation {
 		case WriteOpRedirect, WriteOpHeredoc:
-			// Overwrite: the last write wins, discarding earlier content.
-			// ContentCaptured is false for appends and uncaptured writes.
-			content, ok = fw.Content, fw.ContentCaptured
+			// Overwrite: the last write wins, discarding earlier content. Only
+			// captured content (an exact reconstruction) counts - a heredoc body
+			// fed to cat, or literal echo/printf output - otherwise ok stays
+			// false so callers fall back to reading the file from disk.
+			content, ok = fw.CapturedOverwrite()
 		default:
 			// Append, tee, cp, mv: the resulting bytes can't be reconstructed
 			// from the command alone (prior content or trailing newlines are

--- a/pkg/parser/bash.go
+++ b/pkg/parser/bash.go
@@ -116,18 +116,19 @@ func (r *ParseResult) GetFirstGitWorkingDir() string {
 }
 
 // InlineFileContent returns the content written to path before the consumer at
-// source position "before", and whether that content was reconstructed exactly.
+// source position "before", and whether that content could be reconstructed.
 // workDir is the consumer's effective working directory (from cd or git -C),
 // used to resolve a relative path so writes in a different directory don't match.
 //
 // Only writes preceding that position (in source order, which models shell
 // execution order for sequential commands) are considered, so a write that
 // happens after the consumer - e.g. "git commit -F f && cat > f <<EOF" - is
-// ignored. The only content the parser captures exactly is an overwrite heredoc
-// fed to a verbatim copier (e.g. "cat > f <<EOF ... EOF"); the last such
-// overwrite to the resolved path wins. Appends (">>"), plain redirects, heredocs
-// on transforming commands, and tee/cp/mv leave the result uncertain, so ok is
-// false and callers should fall back to reading the file from disk.
+// ignored. The parser reconstructs two overwrite forms: a heredoc fed to a
+// verbatim copier ("cat > f <<EOF ... EOF"), captured exactly, and a literal
+// echo/printf redirect ("printf '%s' msg > f"), captured best-effort
+// (normalized). The last such overwrite to the resolved path wins. Appends
+// (">>"), heredocs on transforming commands, and tee/cp/mv leave the result
+// uncertain, so ok is false and callers should fall back to reading from disk.
 //
 // This lets validators inspect "git commit -F f" messages when f is created
 // inline (e.g. "cat > f <<EOF ... EOF; git commit -F f"), since f does not

--- a/pkg/parser/bash_test.go
+++ b/pkg/parser/bash_test.go
@@ -1026,8 +1026,10 @@ EOF`
 			Expect(ok).To(BeFalse())
 		})
 
-		It("is uncertain for a plain (uncaptured) redirect", func() {
-			result, err := p.Parse("echo body > msg.txt")
+		It("is uncertain for a redirect whose output can't be reconstructed", func() {
+			// A non-echo/printf producer's output cannot be reproduced from the
+			// command alone, so the write is not captured.
+			result, err := p.Parse("date > msg.txt")
 			Expect(err).NotTo(HaveOccurred())
 
 			_, ok := result.InlineFileContent("msg.txt", "", afterAll)
@@ -1035,7 +1037,7 @@ EOF`
 		})
 
 		It("recovers when a captured heredoc follows an uncertain write", func() {
-			cmd := "echo body > msg.txt\n" +
+			cmd := "date > msg.txt\n" +
 				"cat > msg.txt <<'EOF'\nfeat: x\nEOF"
 			result, err := p.Parse(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -1043,6 +1045,77 @@ EOF`
 			content, ok := result.InlineFileContent("msg.txt", "", afterAll)
 			Expect(ok).To(BeTrue())
 			Expect(content).To(Equal("feat: x\n"))
+		})
+
+		It("captures a literal echo overwrite redirect", func() {
+			result, err := p.Parse("echo 'feat: subject' > msg.txt")
+			Expect(err).NotTo(HaveOccurred())
+
+			content, ok := result.InlineFileContent("msg.txt", "", afterAll)
+			Expect(ok).To(BeTrue())
+			Expect(content).To(Equal("feat: subject"))
+		})
+
+		It("captures a literal printf overwrite redirect", func() {
+			result, err := p.Parse(`printf '%s' 'feat: subject' > msg.txt`)
+			Expect(err).NotTo(HaveOccurred())
+
+			content, ok := result.InlineFileContent("msg.txt", "", afterAll)
+			Expect(ok).To(BeTrue())
+			Expect(content).To(Equal("feat: subject"))
+		})
+
+		It("captures a multi-argument printf as title and body", func() {
+			result, err := p.Parse(`printf '%s\n\n%s\n' 'feat: subject' 'body line' > msg.txt`)
+			Expect(err).NotTo(HaveOccurred())
+
+			content, ok := result.InlineFileContent("msg.txt", "", afterAll)
+			Expect(ok).To(BeTrue())
+			Expect(content).To(Equal("feat: subject\n\nbody line"))
+		})
+
+		It("matches a variable redirect target against a variable consumer path", func() {
+			// printf writes to "$MSG" and the consumer reads "$MSG"; both render
+			// to the same token, so they match without resolving the variable.
+			result, err := p.Parse(`printf '%s' 'feat: subject' > "$MSG"`)
+			Expect(err).NotTo(HaveOccurred())
+
+			content, ok := result.InlineFileContent("$MSG", "", afterAll)
+			Expect(ok).To(BeTrue())
+			Expect(content).To(Equal("feat: subject"))
+		})
+
+		It("matches a brace-form variable redirect target", func() {
+			result, err := p.Parse(`printf '%s' 'feat: subject' > "${MSG}"`)
+			Expect(err).NotTo(HaveOccurred())
+
+			content, ok := result.InlineFileContent("${MSG}", "", afterAll)
+			Expect(ok).To(BeTrue())
+			Expect(content).To(Equal("feat: subject"))
+		})
+
+		It("is uncertain for a printf with an unsupported directive", func() {
+			result, err := p.Parse(`printf '%d' 42 > msg.txt`)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, ok := result.InlineFileContent("msg.txt", "", afterAll)
+			Expect(ok).To(BeFalse())
+		})
+
+		It("is uncertain for a redirect whose content contains an expansion", func() {
+			result, err := p.Parse(`echo "$VAR" > msg.txt`)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, ok := result.InlineFileContent("msg.txt", "", afterAll)
+			Expect(ok).To(BeFalse())
+		})
+
+		It("does not capture an append redirect from echo", func() {
+			result, err := p.Parse("echo more >> msg.txt")
+			Expect(err).NotTo(HaveOccurred())
+
+			_, ok := result.InlineFileContent("msg.txt", "", afterAll)
+			Expect(ok).To(BeFalse())
 		})
 
 		It("returns false when no write targets the path", func() {

--- a/pkg/parser/bash_test.go
+++ b/pkg/parser/bash_test.go
@@ -1075,23 +1075,23 @@ EOF`
 		})
 
 		It("matches a variable redirect target against a variable consumer path", func() {
-			// printf writes to "$MSG" and the consumer reads "$MSG"; both render
-			// to the same token, so they match without resolving the variable.
+			// printf writes to "$MSG" and the consumer reads it; both render to the
+			// same braced token, so they match without resolving the variable.
 			result, err := p.Parse(`printf '%s' 'feat: subject' > "$MSG"`)
 			Expect(err).NotTo(HaveOccurred())
 
-			content, ok := result.InlineFileContent("$MSG", "", afterAll)
+			content, ok := result.InlineFileContent("${MSG}", "", afterAll)
 			Expect(ok).To(BeTrue())
 			Expect(content).To(Equal("feat: subject"))
 		})
 
 		It("matches mixed $VAR and ${VAR} forms", func() {
-			// "${MSG}" and "$MSG" canonicalize to the same token, so a redirect
-			// written one way matches a -F path written the other.
+			// "${MSG}" and "$MSG" canonicalize to the same braced token, so a
+			// redirect written one way matches a -F path written the other.
 			result, err := p.Parse(`printf '%s' 'feat: subject' > "${MSG}"`)
 			Expect(err).NotTo(HaveOccurred())
 
-			content, ok := result.InlineFileContent("$MSG", "", afterAll)
+			content, ok := result.InlineFileContent("${MSG}", "", afterAll)
 			Expect(ok).To(BeTrue())
 			Expect(content).To(Equal("feat: subject"))
 		})

--- a/pkg/parser/bash_test.go
+++ b/pkg/parser/bash_test.go
@@ -1096,6 +1096,16 @@ EOF`
 			Expect(content).To(Equal("feat: subject"))
 		})
 
+		It("renders a modified expansion distinctly from the plain name", func() {
+			// "${#MSG}" (length) must not collapse onto "${MSG}", so a redirect to
+			// the length does not satisfy a consumer reading the variable itself.
+			result, err := p.Parse(`printf '%s' 'feat: subject' > "${#MSG}"`)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, ok := result.InlineFileContent("${MSG}", "", afterAll)
+			Expect(ok).To(BeFalse())
+		})
+
 		It("is uncertain for a printf with an unsupported directive", func() {
 			result, err := p.Parse(`printf '%d' 42 > msg.txt`)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/parser/bash_test.go
+++ b/pkg/parser/bash_test.go
@@ -1085,11 +1085,13 @@ EOF`
 			Expect(content).To(Equal("feat: subject"))
 		})
 
-		It("matches a brace-form variable redirect target", func() {
+		It("matches mixed $VAR and ${VAR} forms", func() {
+			// "${MSG}" and "$MSG" canonicalize to the same token, so a redirect
+			// written one way matches a -F path written the other.
 			result, err := p.Parse(`printf '%s' 'feat: subject' > "${MSG}"`)
 			Expect(err).NotTo(HaveOccurred())
 
-			content, ok := result.InlineFileContent("${MSG}", "", afterAll)
+			content, ok := result.InlineFileContent("$MSG", "", afterAll)
 			Expect(ok).To(BeTrue())
 			Expect(content).To(Equal("feat: subject"))
 		})

--- a/pkg/parser/command.go
+++ b/pkg/parser/command.go
@@ -124,20 +124,38 @@ func wordToString(word *syntax.Word) string {
 	return result.String()
 }
 
-// paramExpToString renders a parameter expansion as a stable braced token
-// "${NAME}". Both "$MSG" and "${MSG}" canonicalize to "${MSG}" so a write target
-// and a consumer that name the same variable in different forms still match. The
-// braced form is used even for a "$NAME" source so a real expansion stays
-// distinct from a single-quoted literal like '$NAME' (which keeps its source
-// form and is still validated). Operators inside ${...} (e.g. ":-default") are
-// not reproduced; the token only needs to be identical for the same variable and
-// recognizable as an unresolved expansion so message validation can skip it.
+// paramExpToString renders a parameter expansion as a stable token. A simple
+// reference - "$MSG" or "${MSG}" - canonicalizes to the braced form "${MSG}" so
+// a write target and a consumer that name the same variable in different forms
+// match, and so a real expansion stays distinct from a single-quoted literal like
+// '$MSG' (which keeps its source form and is still validated). An expansion
+// carrying an operator or modifier - "${#MSG}", "${MSG:-default}", "${!MSG}" - is
+// printed verbatim so distinct expansions are not collapsed onto "${MSG}".
 func paramExpToString(pe *syntax.ParamExp) string {
 	if pe == nil || pe.Param == nil {
 		return ""
 	}
 
-	return "${" + pe.Param.Value + "}"
+	canonical := "${" + pe.Param.Value + "}"
+
+	// A short reference ("$NAME", "$@") has no braces and so no operator; use the
+	// canonical braced form directly.
+	if pe.Short {
+		return canonical
+	}
+
+	// A braced reference may carry an operator/modifier. Print it and keep that
+	// form only when it differs from the plain "${NAME}".
+	var b strings.Builder
+	if err := syntax.NewPrinter().Print(&b, pe); err != nil {
+		return canonical
+	}
+
+	if printed := b.String(); printed != canonical {
+		return printed
+	}
+
+	return canonical
 }
 
 // extractHeredocFromCmdSubst extracts heredoc content from command substitution.

--- a/pkg/parser/command.go
+++ b/pkg/parser/command.go
@@ -92,12 +92,12 @@ func wordToString(word *syntax.Word) string {
 		case *syntax.SglQuoted:
 			result.WriteString(p.Value)
 		case *syntax.ParamExp:
-			// Render a variable reference as a stable token (the short form
-			// "$MSG", so "$MSG" and "${MSG}" coincide) instead of dropping it.
-			// Keeping the token preserves argument positions - so "git commit -F
-			// \"$MSG\" -- file" does not misalign -F onto "--" - and lets a
-			// redirect target and a -F path that name the same variable match by
-			// token equality.
+			// Render a variable reference as a stable braced token ("${MSG}")
+			// instead of dropping it. Keeping the token preserves argument
+			// positions - so "git commit -F \"$MSG\" -- file" does not misalign -F
+			// onto "--" - and lets a redirect target and a -F path that name the
+			// same variable match by token equality. The braced form also keeps a
+			// real expansion distinct from a single-quoted literal like '$MSG'.
 			result.WriteString(paramExpToString(p))
 		case *syntax.DblQuoted:
 			for _, dqPart := range p.Parts {
@@ -124,18 +124,20 @@ func wordToString(word *syntax.Word) string {
 	return result.String()
 }
 
-// paramExpToString renders a parameter expansion as a stable "$NAME" token.
-// Both "$MSG" and "${MSG}" canonicalize to "$MSG" so a write target and a
-// consumer that name the same variable in different forms still match.
-// Operators inside ${...} (e.g. ":-default") are not reproduced; the token only
-// needs to be identical for the same variable and recognizable as an unresolved
-// expansion so message validation can skip it.
+// paramExpToString renders a parameter expansion as a stable braced token
+// "${NAME}". Both "$MSG" and "${MSG}" canonicalize to "${MSG}" so a write target
+// and a consumer that name the same variable in different forms still match. The
+// braced form is used even for a "$NAME" source so a real expansion stays
+// distinct from a single-quoted literal like '$NAME' (which keeps its source
+// form and is still validated). Operators inside ${...} (e.g. ":-default") are
+// not reproduced; the token only needs to be identical for the same variable and
+// recognizable as an unresolved expansion so message validation can skip it.
 func paramExpToString(pe *syntax.ParamExp) string {
 	if pe == nil || pe.Param == nil {
 		return ""
 	}
 
-	return "$" + pe.Param.Value
+	return "${" + pe.Param.Value + "}"
 }
 
 // extractHeredocFromCmdSubst extracts heredoc content from command substitution.

--- a/pkg/parser/command.go
+++ b/pkg/parser/command.go
@@ -92,11 +92,12 @@ func wordToString(word *syntax.Word) string {
 		case *syntax.SglQuoted:
 			result.WriteString(p.Value)
 		case *syntax.ParamExp:
-			// Render a variable reference as a stable token (e.g. "$MSG",
-			// "${MSG}") instead of dropping it. Keeping the token preserves
-			// argument positions - so "git commit -F \"$MSG\" -- file" does not
-			// misalign -F onto "--" - and lets a redirect target and a -F path
-			// that name the same variable match by token equality.
+			// Render a variable reference as a stable token (the short form
+			// "$MSG", so "$MSG" and "${MSG}" coincide) instead of dropping it.
+			// Keeping the token preserves argument positions - so "git commit -F
+			// \"$MSG\" -- file" does not misalign -F onto "--" - and lets a
+			// redirect target and a -F path that name the same variable match by
+			// token equality.
 			result.WriteString(paramExpToString(p))
 		case *syntax.DblQuoted:
 			for _, dqPart := range p.Parts {
@@ -123,21 +124,18 @@ func wordToString(word *syntax.Word) string {
 	return result.String()
 }
 
-// paramExpToString renders a parameter expansion as a stable source-like token:
-// "$NAME" for the short form and "${NAME}" otherwise. Operators inside ${...}
-// (e.g. ":-default") are not reproduced; the token only needs to be identical
-// for the same variable so a write target and a consumer can be matched, and to
-// be recognizable as an unresolved expansion so message validation can skip it.
+// paramExpToString renders a parameter expansion as a stable "$NAME" token.
+// Both "$MSG" and "${MSG}" canonicalize to "$MSG" so a write target and a
+// consumer that name the same variable in different forms still match.
+// Operators inside ${...} (e.g. ":-default") are not reproduced; the token only
+// needs to be identical for the same variable and recognizable as an unresolved
+// expansion so message validation can skip it.
 func paramExpToString(pe *syntax.ParamExp) string {
 	if pe == nil || pe.Param == nil {
 		return ""
 	}
 
-	if pe.Short {
-		return "$" + pe.Param.Value
-	}
-
-	return "${" + pe.Param.Value + "}"
+	return "$" + pe.Param.Value
 }
 
 // extractHeredocFromCmdSubst extracts heredoc content from command substitution.

--- a/pkg/parser/command.go
+++ b/pkg/parser/command.go
@@ -91,11 +91,20 @@ func wordToString(word *syntax.Word) string {
 			result.WriteString(p.Value)
 		case *syntax.SglQuoted:
 			result.WriteString(p.Value)
+		case *syntax.ParamExp:
+			// Render a variable reference as a stable token (e.g. "$MSG",
+			// "${MSG}") instead of dropping it. Keeping the token preserves
+			// argument positions - so "git commit -F \"$MSG\" -- file" does not
+			// misalign -F onto "--" - and lets a redirect target and a -F path
+			// that name the same variable match by token equality.
+			result.WriteString(paramExpToString(p))
 		case *syntax.DblQuoted:
 			for _, dqPart := range p.Parts {
 				switch dqp := dqPart.(type) {
 				case *syntax.Lit:
 					result.WriteString(dqp.Value)
+				case *syntax.ParamExp:
+					result.WriteString(paramExpToString(dqp))
 				case *syntax.CmdSubst:
 					// Handle command substitution (e.g., "$(cat <<'EOF' ... EOF)")
 					if heredoc := extractHeredocFromCmdSubst(dqp); heredoc != "" {
@@ -112,6 +121,23 @@ func wordToString(word *syntax.Word) string {
 	}
 
 	return result.String()
+}
+
+// paramExpToString renders a parameter expansion as a stable source-like token:
+// "$NAME" for the short form and "${NAME}" otherwise. Operators inside ${...}
+// (e.g. ":-default") are not reproduced; the token only needs to be identical
+// for the same variable so a write target and a consumer can be matched, and to
+// be recognizable as an unresolved expansion so message validation can skip it.
+func paramExpToString(pe *syntax.ParamExp) string {
+	if pe == nil || pe.Param == nil {
+		return ""
+	}
+
+	if pe.Short {
+		return "$" + pe.Param.Value
+	}
+
+	return "${" + pe.Param.Value + "}"
 }
 
 // extractHeredocFromCmdSubst extracts heredoc content from command substitution.

--- a/pkg/parser/files.go
+++ b/pkg/parser/files.go
@@ -60,25 +60,28 @@ type FileWrite struct {
 	// on transforming commands (grep, sed, ...), plain redirects, and tee/cp/mv,
 	// where the content cannot be reconstructed from the command alone.
 	ContentCaptured bool
-	// RedirectContent holds the exact bytes a plain overwrite redirect (">")
-	// from a literal echo/printf produced. It is captured for inline
-	// commit-message recovery only (e.g. printf '%s' msg > "$MSG"; git commit -F
-	// "$MSG") and is deliberately kept out of Content so it is NOT fanned out to
-	// file validators - linting partial program text written with echo/printf
-	// (e.g. "printf 'package x' > f.go") would produce spurious failures.
+	// RedirectContent holds the text a plain overwrite redirect (">") from a
+	// literal echo/printf produced, captured for inline commit-message recovery
+	// only (e.g. printf '%s' msg > "$MSG"; git commit -F "$MSG"). It is a
+	// best-effort reconstruction - a trailing newline is dropped and echo
+	// arguments are space-joined - which is sufficient for message validation
+	// (callers trim anyway). It is deliberately kept out of Content so it is NOT
+	// fanned out to file validators - linting partial program text written with
+	// echo/printf (e.g. "printf 'package x' > f.go") would produce spurious
+	// failures.
 	RedirectContent string
-	// RedirectContentCaptured reports whether RedirectContent holds the exact
-	// bytes written. It is true only for an overwrite redirect (">", not ">>")
-	// whose producer is a literal echo or a printf using only %s/%% directives
-	// and known escapes; otherwise the output cannot be reproduced exactly.
+	// RedirectContentCaptured reports whether RedirectContent was reconstructed.
+	// It is true only for an overwrite redirect (">", not ">>") whose producer is
+	// a literal echo or a printf using only %s/%% directives and known escapes;
+	// otherwise the output cannot be reproduced.
 	RedirectContentCaptured bool
 }
 
-// CapturedOverwrite returns the exact bytes an overwrite write produced and
-// whether they were captured. Heredoc bodies are stored in Content; literal
-// echo/printf output is stored in RedirectContent (kept separate so it is not
-// linted as a file). Appends and transforming or copying commands capture
-// nothing, so ok is false for them.
+// CapturedOverwrite returns the reconstructed content an overwrite write produced
+// and whether it was captured. Heredoc bodies (stored in Content) are exact;
+// literal echo/printf output (stored in RedirectContent, kept separate so it is
+// not linted as a file) is a best-effort, normalized reconstruction. Appends and
+// transforming or copying commands capture nothing, so ok is false for them.
 func (f FileWrite) CapturedOverwrite() (string, bool) {
 	if f.ContentCaptured {
 		return f.Content, true

--- a/pkg/parser/files.go
+++ b/pkg/parser/files.go
@@ -60,6 +60,35 @@ type FileWrite struct {
 	// on transforming commands (grep, sed, ...), plain redirects, and tee/cp/mv,
 	// where the content cannot be reconstructed from the command alone.
 	ContentCaptured bool
+	// RedirectContent holds the exact bytes a plain overwrite redirect (">")
+	// from a literal echo/printf produced. It is captured for inline
+	// commit-message recovery only (e.g. printf '%s' msg > "$MSG"; git commit -F
+	// "$MSG") and is deliberately kept out of Content so it is NOT fanned out to
+	// file validators - linting partial program text written with echo/printf
+	// (e.g. "printf 'package x' > f.go") would produce spurious failures.
+	RedirectContent string
+	// RedirectContentCaptured reports whether RedirectContent holds the exact
+	// bytes written. It is true only for an overwrite redirect (">", not ">>")
+	// whose producer is a literal echo or a printf using only %s/%% directives
+	// and known escapes; otherwise the output cannot be reproduced exactly.
+	RedirectContentCaptured bool
+}
+
+// CapturedOverwrite returns the exact bytes an overwrite write produced and
+// whether they were captured. Heredoc bodies are stored in Content; literal
+// echo/printf output is stored in RedirectContent (kept separate so it is not
+// linted as a file). Appends and transforming or copying commands capture
+// nothing, so ok is false for them.
+func (f FileWrite) CapturedOverwrite() (string, bool) {
+	if f.ContentCaptured {
+		return f.Content, true
+	}
+
+	if f.RedirectContentCaptured {
+		return f.RedirectContent, true
+	}
+
+	return "", false
 }
 
 // String returns a string representation of the file write operation.

--- a/pkg/parser/files_test.go
+++ b/pkg/parser/files_test.go
@@ -175,6 +175,36 @@ var _ = Describe("Files", func() {
 				Expect(fw.Path).To(Equal("tmp/output.txt"))
 				Expect(fw.IsProtectedPath()).To(BeFalse())
 			})
+
+			It("captures literal output in RedirectContent, not Content", func() {
+				// The dispatcher fans out FileWrite.Content to file validators, so
+				// echo/printf output must stay in RedirectContent to avoid linting
+				// partial program text (e.g. gofumpt on "printf 'package x' > f.go").
+				result, err := p.Parse(`printf 'package x' > f.go`)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.FileWrites).To(HaveLen(1))
+
+				fw := result.FileWrites[0]
+				Expect(fw.Content).To(BeEmpty())
+				Expect(fw.RedirectContent).To(Equal("package x"))
+				Expect(fw.RedirectContentCaptured).To(BeTrue())
+
+				content, ok := fw.CapturedOverwrite()
+				Expect(ok).To(BeTrue())
+				Expect(content).To(Equal("package x"))
+			})
+
+			It("does not capture content for an append redirect", func() {
+				result, err := p.Parse(`printf 'package x' >> f.go`)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.FileWrites).To(HaveLen(1))
+
+				fw := result.FileWrites[0]
+				Expect(fw.RedirectContentCaptured).To(BeFalse())
+
+				_, ok := fw.CapturedOverwrite()
+				Expect(ok).To(BeFalse())
+			})
 		})
 
 		Context("with tee command", func() {

--- a/pkg/parser/files_test.go
+++ b/pkg/parser/files_test.go
@@ -205,6 +205,18 @@ var _ = Describe("Files", func() {
 				_, ok := fw.CapturedOverwrite()
 				Expect(ok).To(BeFalse())
 			})
+
+			It("does not panic on a redirected block", func() {
+				// "{ ...; } > out" is a redirected block, not a simple command, so
+				// the producer CallExpr is nil; capture must be skipped, not crash.
+				result, err := p.Parse("{ echo hi; } > out.txt")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.FileWrites).To(HaveLen(1))
+
+				fw := result.FileWrites[0]
+				Expect(fw.Path).To(Equal("out.txt"))
+				Expect(fw.RedirectContentCaptured).To(BeFalse())
+			})
 		})
 
 		Context("with tee command", func() {

--- a/pkg/parser/git_test.go
+++ b/pkg/parser/git_test.go
@@ -417,15 +417,15 @@ EOF
 		})
 
 		It("keeps a variable -F value aligned with the -- separator", func() {
-			// "$MSG" renders to a stable token, so -F captures it instead of
-			// grabbing "--", and the pathspec stays a positional argument.
+			// "$MSG" renders to a stable braced token, so -F captures it instead
+			// of grabbing "--", and the pathspec stays a positional argument.
 			result, err := p.Parse(`git commit -sS -F "$MSG" -- file.go`)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.GitOperations).To(HaveLen(1))
 
 			gitCmd, err := parser.ParseGitCommand(result.GitOperations[0])
 			Expect(err).NotTo(HaveOccurred())
-			Expect(gitCmd.GetFlagValue("-F")).To(Equal("$MSG"))
+			Expect(gitCmd.GetFlagValue("-F")).To(Equal("${MSG}"))
 			Expect(gitCmd.Args).To(ContainElement("file.go"))
 		})
 	})

--- a/pkg/parser/git_test.go
+++ b/pkg/parser/git_test.go
@@ -415,6 +415,19 @@ EOF
 			Expect(gitPush.Subcommand).To(Equal("push"))
 			Expect(gitPush.ExtractRemote()).To(Equal("upstream"))
 		})
+
+		It("keeps a variable -F value aligned with the -- separator", func() {
+			// "$MSG" renders to a stable token, so -F captures it instead of
+			// grabbing "--", and the pathspec stays a positional argument.
+			result, err := p.Parse(`git commit -sS -F "$MSG" -- file.go`)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.GitOperations).To(HaveLen(1))
+
+			gitCmd, err := parser.ParseGitCommand(result.GitOperations[0])
+			Expect(err).NotTo(HaveOccurred())
+			Expect(gitCmd.GetFlagValue("-F")).To(Equal("$MSG"))
+			Expect(gitCmd.Args).To(ContainElement("file.go"))
+		})
 	})
 
 	Describe("GetWorkingDirectory", func() {


### PR DESCRIPTION
## Motivation

Follow-up to #501. That PR validated `git commit -F <file>` when the file was written inline with a heredoc. A related form still slipped through: a message built with `printf` and referenced through a variable -

```
printf '%s\n\n%s\n' 'feat(x): title' 'body' > "$MSG"
git commit -sS -F "$MSG"
```

bypassed validation entirely. The variable `"$MSG"` rendered to an empty string in the parser, so the argument was dropped, `-F` grabbed the `--` pathspec separator, and the hook reported `failed to read commit message file --`.

## Implementation

The word renderer now emits a stable token for a parameter expansion (`$MSG`, `${MSG}`) instead of dropping it. That keeps argument positions aligned and lets a redirect target and a `-F` path naming the same variable match by token equality.

A literal `echo`/`printf` overwrite redirect is captured into a separate `RedirectContent` field so the commit validator can recover the message, while the dispatcher keeps reading only `Content` - partial program text written with a redirect (`printf 'package x' > f.go`) is still never linted as a file. The printf reader interprets multi-argument `%s` formats so a title and body written with one `printf` are reconstructed correctly.

Rendering variables as tokens also exposed them to validators that check argument values. The commit, push, and branch validators now skip a value that is a bare variable, since the hook cannot see its runtime content - this avoids newly blocking commands like `git push $REMOTE $BRANCH` or `git checkout -b "$BRANCH"`.

## Testing

`mise run test` and `mise run lint` pass. Added parser coverage for variable-token rendering, printf interpretation, and redirect capture, plus validator coverage for the screenshot case, the `-F "$MSG" -- file` regression, and the bare-variable skip in the commit, push, and branch validators.
