### PR TITLE
fix(git): ignore trailing flags in branch name

### DIFF
--- a/internal/validators/git/branch.go
+++ b/internal/validators/git/branch.go
@@ -231,17 +231,20 @@ func (*BranchValidator) createSpaceError() *validator.Result {
 	return validator.FailWithRef(validator.RefGitBranchName, message)
 }
 
-// extractBranchName extracts the new branch name from a branch-creation command:
-// git checkout -b/--branch <branch>, git switch -c/--create/-C/--force-create
-// <branch>, or git branch <branch>. In each form the new name is the first
-// positional argument (any start-point follows it). The creation flags are
-// boolean in the parser, so the branch name lands in Args rather than next to
-// the flag - reading the token after the flag would instead pick up a trailing
-// option such as "--quiet" in "git checkout -b fix/foo main --quiet". The bash
-// parser preserves quoted spaces within a single argument.
+// extractBranchName extracts the new branch name from a branch-creation command.
+//
+// For checkout and switch the parser captures the name as the creation flag's
+// value (-b/--branch, -c/--create, -C/--force-create), so it is read from there
+// - this both ignores trailing options like "--quiet" in
+// "git checkout -b fix/foo main --quiet" and still catches a dash-prefixed name
+// such as "git checkout -b --quiet". For git branch the new name is the first
+// positional argument (any start-point follows it). The bash parser preserves
+// quoted spaces within a single argument.
 func (*BranchValidator) extractBranchName(gitCmd *parser.GitCommand) string {
 	switch gitCmd.Subcommand {
-	case "checkout", "branch", "switch":
+	case "checkout", "switch":
+		return gitCmd.ExtractBranchName()
+	case "branch":
 		if len(gitCmd.Args) > 0 {
 			return gitCmd.Args[0]
 		}

--- a/internal/validators/git/branch.go
+++ b/internal/validators/git/branch.go
@@ -231,61 +231,20 @@ func (*BranchValidator) createSpaceError() *validator.Result {
 	return validator.FailWithRef(validator.RefGitBranchName, message)
 }
 
-// extractBranchName extracts the branch name from a git command.
-func (v *BranchValidator) extractBranchName(gitCmd *parser.GitCommand) string {
+// extractBranchName extracts the new branch name from a branch-creation command:
+// git checkout -b/--branch <branch>, git switch -c/--create/-C/--force-create
+// <branch>, or git branch <branch>. In each form the new name is the first
+// positional argument (any start-point follows it). The creation flags are
+// boolean in the parser, so the branch name lands in Args rather than next to
+// the flag - reading the token after the flag would instead pick up a trailing
+// option such as "--quiet" in "git checkout -b fix/foo main --quiet". The bash
+// parser preserves quoted spaces within a single argument.
+func (*BranchValidator) extractBranchName(gitCmd *parser.GitCommand) string {
 	switch gitCmd.Subcommand {
-	case "checkout":
-		return v.extractCheckoutBranchName(gitCmd)
-	case "branch":
-		return v.extractBranchCommandName(gitCmd)
-	case "switch":
-		return v.extractSwitchBranchName(gitCmd)
-	default:
-		return ""
-	}
-}
-
-// extractCheckoutBranchName extracts the branch name from git checkout -b <branch> [start-point].
-// The bash parser handles quoted strings, preserving spaces in a single argument.
-func (*BranchValidator) extractCheckoutBranchName(gitCmd *parser.GitCommand) string {
-	for _, flag := range checkoutCreateFlags {
-		for i, f := range gitCmd.Flags {
-			if f == flag && i+1 < len(gitCmd.Flags) {
-				return gitCmd.Flags[i+1]
-			}
+	case "checkout", "branch", "switch":
+		if len(gitCmd.Args) > 0 {
+			return gitCmd.Args[0]
 		}
-	}
-
-	if len(gitCmd.Args) > 0 {
-		return gitCmd.Args[0]
-	}
-
-	return ""
-}
-
-// extractBranchCommandName extracts the branch name from git branch <branch> [start-point].
-// The bash parser handles quoted strings, preserving spaces in a single argument.
-func (*BranchValidator) extractBranchCommandName(gitCmd *parser.GitCommand) string {
-	if len(gitCmd.Args) > 0 {
-		return gitCmd.Args[0]
-	}
-
-	return ""
-}
-
-// extractSwitchBranchName extracts the branch name from git switch -c <branch> [start-point].
-// The bash parser handles quoted strings, preserving spaces in a single argument.
-func (*BranchValidator) extractSwitchBranchName(gitCmd *parser.GitCommand) string {
-	for _, flag := range switchCreateFlags {
-		for i, f := range gitCmd.Flags {
-			if f == flag && i+1 < len(gitCmd.Flags) {
-				return gitCmd.Flags[i+1]
-			}
-		}
-	}
-
-	if len(gitCmd.Args) > 0 {
-		return gitCmd.Args[0]
 	}
 
 	return ""

--- a/internal/validators/git/branch_test.go
+++ b/internal/validators/git/branch_test.go
@@ -161,6 +161,14 @@ var _ = Describe("BranchValidator", func() {
 				Expect(result.Message).To(ContainSubstring("type/description"))
 				Expect(result.Message).NotTo(ContainSubstring("--quiet"))
 			})
+
+			It("should not be bypassed by a dash-prefixed branch name", func() {
+				// "--quiet" as the branch name is captured as the -b value, so it
+				// is validated (and rejected) rather than silently skipped.
+				ctx.ToolInput.Command = "git checkout -b --quiet"
+				result := v.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeFalse())
+			})
 		})
 	})
 
@@ -212,6 +220,15 @@ var _ = Describe("BranchValidator", func() {
 				ctx.ToolInput.Command = "git switch -C feat/force-create"
 				result := v.Validate(context.Background(), ctx)
 				Expect(result.Passed).To(BeTrue())
+			})
+
+			It("should validate the force-created branch name", func() {
+				// -C takes the branch name as its value; the name is validated
+				// rather than skipped.
+				ctx.ToolInput.Command = "git switch -C BadName"
+				result := v.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeFalse())
+				Expect(result.Message).To(ContainSubstring("lowercase"))
 			})
 		})
 

--- a/internal/validators/git/branch_test.go
+++ b/internal/validators/git/branch_test.go
@@ -146,6 +146,22 @@ var _ = Describe("BranchValidator", func() {
 				Expect(result.Passed).To(BeFalse())
 			})
 		})
+
+		Context("with trailing flags after the branch name", func() {
+			It("should pass and ignore a trailing --quiet", func() {
+				ctx.ToolInput.Command = "git checkout -b feat/with-flag main --quiet"
+				result := v.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeTrue())
+			})
+
+			It("should validate the branch name, not the trailing flag", func() {
+				ctx.ToolInput.Command = "git checkout -b add-feature --quiet"
+				result := v.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeFalse())
+				Expect(result.Message).To(ContainSubstring("type/description"))
+				Expect(result.Message).NotTo(ContainSubstring("--quiet"))
+			})
+		})
 	})
 
 	Describe("git switch", func() {
@@ -167,6 +183,12 @@ var _ = Describe("BranchValidator", func() {
 				result := v.Validate(context.Background(), ctx)
 				Expect(result.Passed).To(BeFalse())
 				Expect(result.Message).To(ContainSubstring("spaces"))
+			})
+
+			It("should pass and ignore a trailing --quiet", func() {
+				ctx.ToolInput.Command = "git switch -c feat/new-feature main --quiet"
+				result := v.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeTrue())
 			})
 		})
 

--- a/pkg/parser/git.go
+++ b/pkg/parser/git.go
@@ -2,13 +2,20 @@ package parser
 
 import (
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/cockroachdb/errors"
 )
 
-// flagMessage is the short git/gh message flag.
-const flagMessage = "-m"
+const (
+	// flagMessage is the short git/gh message flag.
+	flagMessage = "-m"
+	// flagDashC is the "-C" flag, whose meaning is subcommand-specific: a repo
+	// path for the top-level git command, --reuse-message for commit, and
+	// --force-create for switch.
+	flagDashC = "-C"
+)
 
 var (
 	// ErrNotGitCommand is returned when the command is not a git command.
@@ -31,7 +38,7 @@ type GitCommand struct {
 
 // Global git options that take a value.
 var globalOptionsWithValue = map[string]bool{
-	"-C":                   true,
+	flagDashC:              true,
 	"--git-dir":            true,
 	"--work-tree":          true,
 	"-c":                   true,
@@ -55,16 +62,34 @@ var globalOptionsWithValue = map[string]bool{
 	"--list-cmds":          true,
 }
 
-// Flags that take values.
+// Flags that take a value across all subcommands.
 var flagsWithValues = map[string]bool{
 	flagMessage:       true,
 	"--message":       true,
 	"-F":              true,
 	"--file":          true,
-	"-C":              true,
+	flagDashC:         true,
 	"--reuse-message": true,
-	"-c":              false, // -c for switch/checkout is a boolean flag
-	"-b":              false, // -b for checkout is a boolean flag
+}
+
+// branchCreationFlags consume the following token as the new branch name for the
+// checkout and switch subcommands, listed in branch-name extraction order. These
+// letters mean other things for other subcommands (e.g. -C is commit's
+// reuse-message), so they are only treated as value-taking for checkout/switch.
+var branchCreationFlags = []string{
+	"-b", "--branch", // checkout
+	"-c", "--create", flagDashC, "--force-create", // switch
+}
+
+// flagTakesValue reports whether flag consumes the next token as its value within
+// the given subcommand.
+func flagTakesValue(flag, subcommand string) bool {
+	if (subcommand == "checkout" || subcommand == "switch") &&
+		slices.Contains(branchCreationFlags, flag) {
+		return true
+	}
+
+	return flagsWithValues[flag]
 }
 
 // ParseGitCommand parses a Command into a GitCommand.
@@ -188,7 +213,7 @@ func addFlag(flag string, args []string, idx int, gitCmd *GitCommand) int {
 	gitCmd.Flags = append(gitCmd.Flags, flag)
 
 	// Check if this flag takes a value
-	if takesValue, exists := flagsWithValues[flag]; exists && takesValue {
+	if flagTakesValue(flag, gitCmd.Subcommand) {
 		if idx+1 < len(args) {
 			// Only store the first value for flags that can repeat (e.g., -m for title)
 			if _, alreadySet := gitCmd.FlagMap[flag]; !alreadySet {
@@ -221,8 +246,7 @@ func parseCombinedFlags(combined string, args []string, idx int, gitCmd *GitComm
 		gitCmd.Flags = append(gitCmd.Flags, flag)
 
 		// Check if this flag takes a value
-		takesValue, exists := flagsWithValues[flag]
-		if !exists || !takesValue {
+		if !flagTakesValue(flag, gitCmd.Subcommand) {
 			continue
 		}
 
@@ -300,9 +324,15 @@ func (g *GitCommand) ExtractRemote() string {
 // ExtractBranchName extracts branch name from various git commands.
 func (g *GitCommand) ExtractBranchName() string {
 	switch g.Subcommand {
-	case "checkout":
-		// git checkout [-b] <branch>
-		// Branch name is always in Args (first positional arg)
+	case "checkout", "switch":
+		// git checkout -b/--branch <branch>, git switch -c/--create/-C/
+		// --force-create <branch>: the creation flag captures the new branch
+		// name (including a dash-prefixed one). Existing-branch checkout/switch
+		// has no creation flag, so fall back to the first positional argument.
+		if name := g.branchCreationName(); name != "" {
+			return name
+		}
+
 		if len(g.Args) > 0 {
 			return g.Args[0]
 		}
@@ -315,18 +345,23 @@ func (g *GitCommand) ExtractBranchName() string {
 			return g.Args[len(g.Args)-1]
 		}
 
-	case "switch":
-		// git switch [-c] <branch>
-		// git switch <branch>
-		// Branch name is always in Args (first positional arg)
-		if len(g.Args) > 0 {
-			return g.Args[0]
-		}
-
 	case "push", "pull":
 		// git push/pull <remote> <branch>
 		if len(g.Args) > 1 {
 			return g.Args[1]
+		}
+	}
+
+	return ""
+}
+
+// branchCreationName returns the value captured for a checkout/switch branch
+// creation flag (-b, --branch, -c, --create, -C, --force-create), or "" when no
+// such flag is present.
+func (g *GitCommand) branchCreationName() string {
+	for _, flag := range branchCreationFlags {
+		if name := g.FlagMap[flag]; name != "" {
+			return name
 		}
 	}
 
@@ -357,7 +392,7 @@ func (g *GitCommand) ExtractFilePaths() []string {
 func (g *GitCommand) GetWorkingDirectory() string {
 	cdDir := g.WorkingDirectory
 
-	cDir, hasC := g.GlobalOptions["-C"]
+	cDir, hasC := g.GlobalOptions[flagDashC]
 	if !hasC {
 		return cdDir
 	}

--- a/pkg/parser/git.go
+++ b/pkg/parser/git.go
@@ -11,11 +11,13 @@ import (
 const (
 	// flagMessage is the short git/gh message flag.
 	flagMessage = "-m"
-	// flagDashC is the "-C" flag. Its meaning is subcommand-specific and handled
-	// per context rather than globally - for example a repo path for the
-	// top-level git command, --reuse-message for commit, --force-create for
-	// switch, and force-copy for branch.
-	flagDashC = "-C"
+	// flagUpperC ("-C") and flagLowerC ("-c") are reused with a different meaning
+	// per subcommand, handled per context rather than globally: -C is a repo path
+	// for the top-level git command, --reuse-message for commit, --force-create
+	// for switch, and force-copy for branch; -c is a config override for the
+	// top-level command, --create for switch, and copy for branch.
+	flagUpperC = "-C"
+	flagLowerC = "-c"
 )
 
 var (
@@ -39,10 +41,10 @@ type GitCommand struct {
 
 // Global git options that take a value.
 var globalOptionsWithValue = map[string]bool{
-	flagDashC:              true,
+	flagUpperC:             true,
 	"--git-dir":            true,
 	"--work-tree":          true,
-	"-c":                   true,
+	flagLowerC:             true,
 	"--namespace":          true,
 	"--super-prefix":       true,
 	"--config-env":         true,
@@ -69,25 +71,43 @@ var flagsWithValues = map[string]bool{
 	"--message":       true,
 	"-F":              true,
 	"--file":          true,
-	flagDashC:         true,
+	flagUpperC:        true,
 	"--reuse-message": true,
 }
 
-// branchCreationFlags consume the following token as the new branch name for the
-// checkout and switch subcommands, listed in branch-name extraction order. These
-// letters mean other things for other subcommands (e.g. -C is commit's
-// reuse-message, value-taking via flagsWithValues), so they are only treated as
-// branch-creation flags for checkout/switch.
-var branchCreationFlags = []string{
-	"-b", "--branch", // checkout
-	"-c", "--create", flagDashC, "--force-create", // switch
+// checkoutCreationFlags and switchCreationFlags consume the following token as
+// the new branch name for their own subcommand ("git checkout -b feat/x",
+// "git switch -C feat/x"), listed in branch-name extraction order. They are kept
+// per subcommand because the letters mean other things elsewhere (e.g. -C is
+// commit's reuse-message, value-taking via flagsWithValues), so only a
+// subcommand's own creation flags capture a branch name.
+var (
+	checkoutCreationFlags = []string{"-b", "--branch"}
+	switchCreationFlags   = []string{flagLowerC, "--create", flagUpperC, "--force-create"}
+)
+
+// branchRenameCopyFlags mark a "git branch" rename or copy, which takes an
+// optional old name followed by the new name - so the new name is the last
+// positional argument rather than the first.
+var branchRenameCopyFlags = []string{"-m", "-M", "--move", flagLowerC, flagUpperC, "--copy"}
+
+// branchCreationFlagsFor returns the branch-creation flags for subcommand, or nil
+// when it has none.
+func branchCreationFlagsFor(subcommand string) []string {
+	switch subcommand {
+	case "checkout":
+		return checkoutCreationFlags
+	case "switch":
+		return switchCreationFlags
+	default:
+		return nil
+	}
 }
 
 // flagTakesValue reports whether flag consumes the next token as its value within
 // the given subcommand.
 func flagTakesValue(flag, subcommand string) bool {
-	if (subcommand == "checkout" || subcommand == "switch") &&
-		slices.Contains(branchCreationFlags, flag) {
+	if slices.Contains(branchCreationFlagsFor(subcommand), flag) {
 		return true
 	}
 
@@ -340,12 +360,18 @@ func (g *GitCommand) ExtractBranchName() string {
 		}
 
 	case "branch":
-		// git branch [-m] <new-branch>
-		// git branch <branch>
-		if len(g.Args) > 0 {
-			// Last arg is the branch name
+		if len(g.Args) == 0 {
+			return ""
+		}
+
+		// Rename/copy (-m/-M/--move, -c/-C/--copy) take an optional old name then
+		// the new name, so the new name is the last positional. Plain creation,
+		// "git branch <new> [start-point]", puts the new name first.
+		if slices.ContainsFunc(branchRenameCopyFlags, g.HasFlag) {
 			return g.Args[len(g.Args)-1]
 		}
+
+		return g.Args[0]
 
 	case "push", "pull":
 		// git push/pull <remote> <branch>
@@ -357,11 +383,10 @@ func (g *GitCommand) ExtractBranchName() string {
 	return ""
 }
 
-// branchCreationName returns the value captured for a checkout/switch branch
-// creation flag (-b, --branch, -c, --create, -C, --force-create), or "" when no
-// such flag is present.
+// branchCreationName returns the value captured for the subcommand's branch
+// creation flag, or "" when no such flag is present.
 func (g *GitCommand) branchCreationName() string {
-	for _, flag := range branchCreationFlags {
+	for _, flag := range branchCreationFlagsFor(g.Subcommand) {
 		if name := g.FlagMap[flag]; name != "" {
 			return name
 		}
@@ -394,7 +419,7 @@ func (g *GitCommand) ExtractFilePaths() []string {
 func (g *GitCommand) GetWorkingDirectory() string {
 	cdDir := g.WorkingDirectory
 
-	cDir, hasC := g.GlobalOptions[flagDashC]
+	cDir, hasC := g.GlobalOptions[flagUpperC]
 	if !hasC {
 		return cdDir
 	}

--- a/pkg/parser/git.go
+++ b/pkg/parser/git.go
@@ -76,17 +76,16 @@ var globalOptionsWithValue = map[string]bool{
 // Flags that take a value regardless of subcommand. Context-dependent flags
 // (-c/-C, and branch's -m) are handled per subcommand in flagTakesValue instead.
 var flagsWithValues = map[string]bool{
-	flagMessage:       true,
-	"--message":       true,
-	"-F":              true,
-	"--file":          true,
-	"--reuse-message": true,
+	flagMessage: true,
+	"--message": true,
+	"-F":        true,
+	"--file":    true,
 }
 
 // commitReuseFlags reuse another commit's message for "git commit" and consume
 // the commit reference: -c/--reedit-message edits the reused message, -C/
 // --reuse-message keeps it as-is.
-var commitReuseFlags = []string{flagLowerC, flagUpperC}
+var commitReuseFlags = []string{flagLowerC, "--reedit-message", flagUpperC, "--reuse-message"}
 
 // checkoutCreationFlags and switchCreationFlags consume the following token as
 // the new branch name for their own subcommand ("git checkout -b feat/x",

--- a/pkg/parser/git.go
+++ b/pkg/parser/git.go
@@ -25,6 +25,7 @@ const (
 	subcmdCheckout = "checkout"
 	subcmdSwitch   = "switch"
 	subcmdBranch   = "branch"
+	subcmdCommit   = "commit"
 )
 
 var (
@@ -72,15 +73,20 @@ var globalOptionsWithValue = map[string]bool{
 	"--list-cmds":          true,
 }
 
-// Flags that take a value across all subcommands.
+// Flags that take a value regardless of subcommand. Context-dependent flags
+// (-c/-C, and branch's -m) are handled per subcommand in flagTakesValue instead.
 var flagsWithValues = map[string]bool{
 	flagMessage:       true,
 	"--message":       true,
 	"-F":              true,
 	"--file":          true,
-	flagUpperC:        true,
 	"--reuse-message": true,
 }
+
+// commitReuseFlags reuse another commit's message for "git commit" and consume
+// the commit reference: -c/--reedit-message edits the reused message, -C/
+// --reuse-message keeps it as-is.
+var commitReuseFlags = []string{flagLowerC, flagUpperC}
 
 // checkoutCreationFlags and switchCreationFlags consume the following token as
 // the new branch name for their own subcommand ("git checkout -b feat/x",
@@ -112,17 +118,26 @@ func branchCreationFlagsFor(subcommand string) []string {
 }
 
 // flagTakesValue reports whether flag consumes the next token as its value within
-// the given subcommand.
+// the given subcommand. It resolves context-dependent flags (-c/-C, branch's -m)
+// per subcommand before falling back to the subcommand-independent set.
 func flagTakesValue(flag, subcommand string) bool {
-	if slices.Contains(branchCreationFlagsFor(subcommand), flag) {
-		return true
-	}
-
-	// For "git branch", -m/-M/--move and -c/-C/--copy are rename/copy mode flags;
-	// the old and new names are positional, so they do not consume a value (unlike
-	// commit's -m/-C, which flagsWithValues would otherwise treat as value-taking).
-	if subcommand == subcmdBranch && slices.Contains(branchRenameCopyFlags, flag) {
-		return false
+	switch subcommand {
+	case subcmdCheckout, subcmdSwitch:
+		// The creation flag captures the new branch name.
+		if slices.Contains(branchCreationFlagsFor(subcommand), flag) {
+			return true
+		}
+	case subcmdBranch:
+		// Rename/copy mode flags (-m/-M/--move, -c/-C/--copy) are boolean; the
+		// old and new names are positional.
+		if slices.Contains(branchRenameCopyFlags, flag) {
+			return false
+		}
+	case subcmdCommit:
+		// -c/-C reuse another commit's message and consume the commit ref.
+		if slices.Contains(commitReuseFlags, flag) {
+			return true
+		}
 	}
 
 	return flagsWithValues[flag]

--- a/pkg/parser/git.go
+++ b/pkg/parser/git.go
@@ -11,9 +11,10 @@ import (
 const (
 	// flagMessage is the short git/gh message flag.
 	flagMessage = "-m"
-	// flagDashC is the "-C" flag, whose meaning is subcommand-specific: a repo
-	// path for the top-level git command, --reuse-message for commit, and
-	// --force-create for switch.
+	// flagDashC is the "-C" flag. Its meaning is subcommand-specific and handled
+	// per context rather than globally - for example a repo path for the
+	// top-level git command, --reuse-message for commit, --force-create for
+	// switch, and force-copy for branch.
 	flagDashC = "-C"
 )
 
@@ -75,7 +76,8 @@ var flagsWithValues = map[string]bool{
 // branchCreationFlags consume the following token as the new branch name for the
 // checkout and switch subcommands, listed in branch-name extraction order. These
 // letters mean other things for other subcommands (e.g. -C is commit's
-// reuse-message), so they are only treated as value-taking for checkout/switch.
+// reuse-message, value-taking via flagsWithValues), so they are only treated as
+// branch-creation flags for checkout/switch.
 var branchCreationFlags = []string{
 	"-b", "--branch", // checkout
 	"-c", "--create", flagDashC, "--force-create", // switch

--- a/pkg/parser/git.go
+++ b/pkg/parser/git.go
@@ -20,6 +20,13 @@ const (
 	flagLowerC = "-c"
 )
 
+// Subcommands whose flag/argument handling needs special-casing.
+const (
+	subcmdCheckout = "checkout"
+	subcmdSwitch   = "switch"
+	subcmdBranch   = "branch"
+)
+
 var (
 	// ErrNotGitCommand is returned when the command is not a git command.
 	ErrNotGitCommand = errors.New("not a git command")
@@ -95,9 +102,9 @@ var branchRenameCopyFlags = []string{"-m", "-M", "--move", flagLowerC, flagUpper
 // when it has none.
 func branchCreationFlagsFor(subcommand string) []string {
 	switch subcommand {
-	case "checkout":
+	case subcmdCheckout:
 		return checkoutCreationFlags
-	case "switch":
+	case subcmdSwitch:
 		return switchCreationFlags
 	default:
 		return nil
@@ -109,6 +116,13 @@ func branchCreationFlagsFor(subcommand string) []string {
 func flagTakesValue(flag, subcommand string) bool {
 	if slices.Contains(branchCreationFlagsFor(subcommand), flag) {
 		return true
+	}
+
+	// For "git branch", -m/-M/--move and -c/-C/--copy are rename/copy mode flags;
+	// the old and new names are positional, so they do not consume a value (unlike
+	// commit's -m/-C, which flagsWithValues would otherwise treat as value-taking).
+	if subcommand == subcmdBranch && slices.Contains(branchRenameCopyFlags, flag) {
+		return false
 	}
 
 	return flagsWithValues[flag]
@@ -346,7 +360,7 @@ func (g *GitCommand) ExtractRemote() string {
 // ExtractBranchName extracts branch name from various git commands.
 func (g *GitCommand) ExtractBranchName() string {
 	switch g.Subcommand {
-	case "checkout", "switch":
+	case subcmdCheckout, subcmdSwitch:
 		// git checkout -b/--branch <branch>, git switch -c/--create/-C/
 		// --force-create <branch>: the creation flag captures the new branch
 		// name (including a dash-prefixed one). Existing-branch checkout/switch
@@ -359,7 +373,7 @@ func (g *GitCommand) ExtractBranchName() string {
 			return g.Args[0]
 		}
 
-	case "branch":
+	case subcmdBranch:
 		if len(g.Args) == 0 {
 			return ""
 		}

--- a/pkg/parser/git_test.go
+++ b/pkg/parser/git_test.go
@@ -229,6 +229,18 @@ EOF
 				Expect(gitCmd.HasFlag("-m")).To(BeTrue())
 				Expect(gitCmd.ExtractBranchName()).To(Equal("new-name"))
 			})
+
+			It("parses single-argument branch rename with -m", func() {
+				cmd := parser.Command{
+					Name: "git",
+					Args: []string{"branch", "-m", "renamed-branch"},
+				}
+
+				gitCmd, err := parser.ParseGitCommand(cmd)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(gitCmd.HasFlag("-m")).To(BeTrue())
+				Expect(gitCmd.ExtractBranchName()).To(Equal("renamed-branch"))
+			})
 		})
 
 		Context("with git switch command", func() {

--- a/pkg/parser/git_test.go
+++ b/pkg/parser/git_test.go
@@ -68,6 +68,18 @@ var _ = Describe("GitCommand", func() {
 				Expect(gitCmd.ExtractCommitMessage()).To(Equal("fix: bug fix"))
 			})
 
+			It("captures the commit ref for -c/-C reuse flags", func() {
+				cmd := parser.Command{
+					Name: "git",
+					Args: []string{"commit", "-c", "HEAD~1"},
+				}
+
+				gitCmd, err := parser.ParseGitCommand(cmd)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(gitCmd.GetFlagValue("-c")).To(Equal("HEAD~1"))
+				Expect(gitCmd.Args).To(BeEmpty())
+			})
+
 			It("uses first -m flag as commit message when multiple -m flags provided", func() {
 				// git commit -m "title" -m "body" should use "title" as the message
 				cmd := parser.Command{

--- a/pkg/parser/git_test.go
+++ b/pkg/parser/git_test.go
@@ -207,6 +207,17 @@ EOF
 				Expect(gitCmd.ExtractBranchName()).To(Equal("new-branch"))
 			})
 
+			It("returns the new branch, not the start-point, on creation", func() {
+				cmd := parser.Command{
+					Name: "git",
+					Args: []string{"branch", "new-branch", "upstream/main"},
+				}
+
+				gitCmd, err := parser.ParseGitCommand(cmd)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(gitCmd.ExtractBranchName()).To(Equal("new-branch"))
+			})
+
 			It("parses branch rename with -m", func() {
 				cmd := parser.Command{
 					Name: "git",

--- a/pkg/parser/git_test.go
+++ b/pkg/parser/git_test.go
@@ -80,6 +80,18 @@ var _ = Describe("GitCommand", func() {
 				Expect(gitCmd.Args).To(BeEmpty())
 			})
 
+			It("captures the commit ref for the --reedit-message long form", func() {
+				cmd := parser.Command{
+					Name: "git",
+					Args: []string{"commit", "--reedit-message", "HEAD~1"},
+				}
+
+				gitCmd, err := parser.ParseGitCommand(cmd)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(gitCmd.GetFlagValue("--reedit-message")).To(Equal("HEAD~1"))
+				Expect(gitCmd.Args).To(BeEmpty())
+			})
+
 			It("uses first -m flag as commit message when multiple -m flags provided", func() {
 				// git commit -m "title" -m "body" should use "title" as the message
 				cmd := parser.Command{

--- a/pkg/parser/git_test.go
+++ b/pkg/parser/git_test.go
@@ -181,6 +181,18 @@ EOF
 				Expect(gitCmd.HasFlag("-b")).To(BeTrue())
 				Expect(gitCmd.ExtractBranchName()).To(Equal("feat/new-feature"))
 			})
+
+			It("captures the -b branch name despite a trailing flag", func() {
+				cmd := parser.Command{
+					Name: "git",
+					Args: []string{"checkout", "-b", "feat/new-feature", "main", "--quiet"},
+				}
+
+				gitCmd, err := parser.ParseGitCommand(cmd)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(gitCmd.HasFlag("--quiet")).To(BeTrue())
+				Expect(gitCmd.ExtractBranchName()).To(Equal("feat/new-feature"))
+			})
 		})
 
 		Context("with git branch command", func() {


### PR DESCRIPTION
## Motivation

The branch-name validator (GIT020) misread a trailing flag as the branch name. `git checkout -b fix/foo main --quiet` was rejected with "Branch name '--quiet' doesn't match". The parser treated the creation flags as boolean, so the branch name went to the positional args while a trailing option landed in the flag list - and a dash-prefixed name (`git checkout -b --quiet`) or `git switch -C <name>` was never validated at all, since the name did not land where the extractor looked.

## Implementation information

The parser now treats each subcommand's branch-creation flags as value-taking, so the new branch name is captured as the creation flag's value: `-b`/`--branch` for checkout and `-c`/`--create`/`-C`/`--force-create` for switch. `GitCommand.ExtractBranchName` and the branch validator read that captured value, falling back to the first positional argument. This is scoped per subcommand so commit's `-c`/`-C` (reuse-message) keep their meaning. The `git branch` extraction also returns the first positional for creation (`git branch <new> [start-point]`) while still returning the last name for rename/copy.

Regression tests cover trailing flags on `checkout -b` and `switch -c`, a dash-prefixed name, `switch -C` validation, parser capture with a trailing flag, and `git branch <new> <start-point>`.

## Supporting documentation

The parser's creation-flag split mirrors `checkoutCreateFlags`/`switchCreateFlags` in the branch validator; `-c`/`-C` are only treated as branch-creation flags for checkout and switch.
