### PR TITLE
fix(git): skip bare-variable PR title and body

### DIFF
--- a/internal/validators/git/pr.go
+++ b/internal/validators/git/pr.go
@@ -395,6 +395,15 @@ func (v *PRValidator) validatePRTitleData(
 		return
 	}
 
+	// A bare variable title (e.g. gh pr create --title "$TITLE") is an unresolved
+	// expansion whose runtime value the hook cannot see, so its format can't be
+	// checked. Skip rather than reject a valid title.
+	if isBarePRExpansion(title) {
+		v.Logger().Debug("PR title is an unresolved expansion; skipping validation", "title", title)
+
+		return
+	}
+
 	// Check title length
 	lengthRule := &TitleLengthRule{
 		MaxLength:                 v.getTitleMaxLength(),
@@ -443,10 +452,43 @@ func (v *PRValidator) validatePRBodyData(body, prType string, allErrors, allWarn
 		return
 	}
 
+	// A bare variable body (e.g. gh pr create --body "$BODY") is an unresolved
+	// expansion the hook cannot inspect, so skip rather than report it as missing
+	// required sections.
+	if isBarePRExpansion(body) {
+		v.Logger().Debug("PR body is an unresolved expansion; skipping validation", "body", body)
+
+		return
+	}
+
 	requireChangelog := v.isRequireChangelog()
 	bodyResult := validatePRBody(body, prType, requireChangelog)
 	*allErrors = append(*allErrors, bodyResult.Errors...)
 	*allWarnings = append(*allWarnings, bodyResult.Warnings...)
+}
+
+// bareShortVarPattern matches a bare short-form shell variable like "$TITLE".
+var bareShortVarPattern = regexp.MustCompile(`^\$[A-Za-z_][A-Za-z0-9_]*$`)
+
+// isBarePRExpansion reports whether a regex-extracted PR field is a single
+// unresolved shell expansion - "$NAME", "${NAME}", or a "$(...)" command
+// substitution. The PR validator reads the title and body from the raw command
+// text, so an expansion appears verbatim; its runtime value can't be inspected,
+// and validating the literal token would wrongly reject a valid PR, so skip it.
+func isBarePRExpansion(s string) bool {
+	s = strings.TrimSpace(s)
+
+	if strings.HasPrefix(s, "$(") && strings.HasSuffix(s, ")") {
+		return true
+	}
+
+	// ${NAME} braced form (shared with the commit/branch validators).
+	if isBareExpansion(s) {
+		return true
+	}
+
+	// $NAME short form.
+	return bareShortVarPattern.MatchString(s)
 }
 
 // validateBaseBranchLabels validates base branch labels

--- a/internal/validators/git/pr.go
+++ b/internal/validators/git/pr.go
@@ -265,6 +265,12 @@ type PRData struct {
 	BaseBranch string
 	Labels     []string
 	HasLabels  bool
+	// TitleIsExpansion / BodyIsExpansion report that the value came from a
+	// double-quoted argument and is a single unresolved shell expansion (e.g.
+	// --title "$TITLE"), so its runtime value can't be validated. Single-quoted
+	// values are literal in shell and are never marked, so they stay validated.
+	TitleIsExpansion bool
+	BodyIsExpansion  bool
 }
 
 // extractPRData extracts PR title, body, base branch, and labels from gh command
@@ -273,9 +279,12 @@ func (v *PRValidator) extractPRData(command string) PRData {
 		Labels: []string{},
 	}
 
-	// Extract title (try double quotes first, then single quotes)
+	// Extract title (try double quotes first, then single quotes). Only a
+	// double-quoted value undergoes shell expansion, so only it can be a bare
+	// expansion to skip; a single-quoted value is a literal and stays validated.
 	if matches := prTitleRegex.FindStringSubmatch(command); len(matches) > 1 {
 		data.Title = matches[1]
+		data.TitleIsExpansion = isBarePRExpansion(matches[1])
 	} else if matches := prTitleSingleRegex.FindStringSubmatch(command); len(matches) > 1 {
 		data.Title = matches[1]
 	}
@@ -296,12 +305,15 @@ func (v *PRValidator) extractPRData(command string) PRData {
 		data.Labels = v.parseLabels(matches[1])
 	}
 
-	// Extract body - try heredoc first, then quoted strings
+	// Extract body - try heredoc first, then quoted strings. As with the title,
+	// only a double-quoted body can be a bare expansion to skip; heredoc bodies
+	// and single-quoted bodies are literal and stay validated.
 	if matches := heredocRegex.FindStringSubmatch(command); len(matches) > 1 {
 		// Add trailing newline for markdownlint MD047 rule
 		data.Body = matches[1] + "\n"
 	} else if matches := bodyRegex.FindStringSubmatch(command); len(matches) > 1 {
 		data.Body = matches[1] + "\n"
+		data.BodyIsExpansion = isBarePRExpansion(matches[1])
 	} else if matches := bodySingleRegex.FindStringSubmatch(command); len(matches) > 1 {
 		data.Body = matches[1] + "\n"
 	}
@@ -340,7 +352,7 @@ func (v *PRValidator) validatePR(ctx context.Context, data PRData) *validator.Re
 	allWarnings := make([]string, 0, typicalWarningCount)
 
 	// 1. Validate PR title
-	v.validatePRTitleData(ctx, data.Title, &allErrors, &allWarnings)
+	v.validatePRTitleData(ctx, data.Title, data.TitleIsExpansion, &allErrors, &allWarnings)
 
 	// 2. Check for forbidden patterns in title and body
 	forbiddenErrors := v.checkForbiddenPatterns(data.Title, data.Body)
@@ -354,7 +366,7 @@ func (v *PRValidator) validatePR(ctx context.Context, data PRData) *validator.Re
 	prType := extractPRType(data.Title, validTypes)
 
 	// 4. Validate PR body
-	v.validatePRBodyData(data.Body, prType, &allErrors, &allWarnings)
+	v.validatePRBodyData(data.Body, prType, data.BodyIsExpansion, &allErrors, &allWarnings)
 
 	// 5. Validate markdown formatting
 	if data.Body != "" {
@@ -384,6 +396,7 @@ func (v *PRValidator) validatePR(ctx context.Context, data PRData) *validator.Re
 func (v *PRValidator) validatePRTitleData(
 	ctx context.Context,
 	title string,
+	titleIsExpansion bool,
 	allErrors, allWarnings *[]string,
 ) {
 	if title == "" {
@@ -397,9 +410,10 @@ func (v *PRValidator) validatePRTitleData(
 
 	// A bare variable title (e.g. gh pr create --title "$TITLE") is an unresolved
 	// expansion whose runtime value the hook cannot see, so its format can't be
-	// checked. Skip rather than reject a valid title.
-	if isBarePRExpansion(title) {
-		v.Logger().Debug("PR title is an unresolved expansion; skipping validation", "title", title)
+	// checked. Skip rather than reject a valid title. The value is omitted from
+	// the log since a "$(...)" form can carry sensitive command content.
+	if titleIsExpansion {
+		v.Logger().Debug("PR title is an unresolved expansion; skipping validation")
 
 		return
 	}
@@ -433,7 +447,11 @@ func (v *PRValidator) validatePRTitleData(
 }
 
 // validatePRBodyData validates the PR body
-func (v *PRValidator) validatePRBodyData(body, prType string, allErrors, allWarnings *[]string) {
+func (v *PRValidator) validatePRBodyData(
+	body, prType string,
+	bodyIsExpansion bool,
+	allErrors, allWarnings *[]string,
+) {
 	requireBody := v.isRequireBody()
 
 	if body == "" {
@@ -454,9 +472,10 @@ func (v *PRValidator) validatePRBodyData(body, prType string, allErrors, allWarn
 
 	// A bare variable body (e.g. gh pr create --body "$BODY") is an unresolved
 	// expansion the hook cannot inspect, so skip rather than report it as missing
-	// required sections.
-	if isBarePRExpansion(body) {
-		v.Logger().Debug("PR body is an unresolved expansion; skipping validation", "body", body)
+	// required sections. The value is omitted from the log since a "$(...)" form
+	// can carry sensitive command content.
+	if bodyIsExpansion {
+		v.Logger().Debug("PR body is an unresolved expansion; skipping validation")
 
 		return
 	}

--- a/internal/validators/git/pr.go
+++ b/internal/validators/git/pr.go
@@ -354,29 +354,43 @@ func (v *PRValidator) validatePR(ctx context.Context, data PRData) *validator.Re
 	// 1. Validate PR title
 	v.validatePRTitleData(ctx, data.Title, data.TitleIsExpansion, &allErrors, &allWarnings)
 
+	// An unresolved expansion (e.g. --title "$TITLE", --body "$(...)") can't be
+	// inspected, so treat it as empty for every content-based check below. This
+	// keeps the raw token from being pattern-matched, linted, used for type
+	// detection, or surfaced in the result.
+	titleForChecks := data.Title
+	if data.TitleIsExpansion {
+		titleForChecks = ""
+	}
+
+	bodyForChecks := data.Body
+	if data.BodyIsExpansion {
+		bodyForChecks = ""
+	}
+
 	// 2. Check for forbidden patterns in title and body
-	forbiddenErrors := v.checkForbiddenPatterns(data.Title, data.Body)
+	forbiddenErrors := v.checkForbiddenPatterns(titleForChecks, bodyForChecks)
 	allErrors = append(allErrors, forbiddenErrors...)
 
 	// 2b. Check for AI attribution in title and body
-	allErrors = append(allErrors, v.checkAIAttribution(data.Title, data.Body)...)
+	allErrors = append(allErrors, v.checkAIAttribution(titleForChecks, bodyForChecks)...)
 
 	// 3. Extract PR type for body validation
 	validTypes := v.getValidTypes()
-	prType := extractPRType(data.Title, validTypes)
+	prType := extractPRType(titleForChecks, validTypes)
 
 	// 4. Validate PR body
 	v.validatePRBodyData(data.Body, prType, data.BodyIsExpansion, &allErrors, &allWarnings)
 
 	// 5. Validate markdown formatting
-	if data.Body != "" {
+	if bodyForChecks != "" {
 		// External markdownlint validation
 		disabledRules := v.getMarkdownDisabledRules()
-		mdResult := ValidatePRMarkdown(ctx, data.Body, disabledRules)
+		mdResult := ValidatePRMarkdown(ctx, bodyForChecks, disabledRules)
 		allWarnings = append(allWarnings, mdResult.Errors...)
 
 		// Internal markdown validation (code block indentation, empty lines, etc.)
-		internalMdResult := validators.AnalyzeMarkdown(data.Body, nil)
+		internalMdResult := validators.AnalyzeMarkdown(bodyForChecks, nil)
 		allWarnings = append(allWarnings, internalMdResult.Warnings...)
 	}
 
@@ -384,12 +398,19 @@ func (v *PRValidator) validatePR(ctx context.Context, data PRData) *validator.Re
 	validateBaseBranchLabels(data, &allErrors)
 
 	// 7. Validate CI label heuristics (if enabled)
-	if v.isCheckCILabelsEnabled() && data.Title != "" && data.Body != "" {
+	if v.isCheckCILabelsEnabled() && titleForChecks != "" && bodyForChecks != "" {
 		ciWarnings := v.checkCILabelHeuristics(data, prType)
 		allWarnings = append(allWarnings, ciWarnings...)
 	}
 
-	return v.buildResult(allErrors, allWarnings, data.Title)
+	// Redact an unresolved-expansion title from the preview so a "$(...)" form is
+	// not echoed back in the hook output.
+	previewTitle := data.Title
+	if data.TitleIsExpansion {
+		previewTitle = "(unresolved expansion)"
+	}
+
+	return v.buildResult(allErrors, allWarnings, previewTitle)
 }
 
 // validatePRTitleData validates the PR title using commit rules.

--- a/internal/validators/git/pr_test.go
+++ b/internal/validators/git/pr_test.go
@@ -1025,6 +1025,90 @@ See docs/api.md'`,
 			Expect(result.Passed).To(BeTrue())
 		})
 
+		It("should pass with a bare variable title", func() {
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{
+					Command: `gh pr create --title "$TITLE" --body "$(cat <<'EOF'
+# PR Title
+
+## Motivation
+
+New feature description
+
+## Implementation information
+
+- Added endpoint
+- Updated documentation
+
+## Supporting documentation
+
+See docs/api.md
+EOF
+)"`,
+				},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeTrue())
+		})
+
+		It("should pass with a braced variable title", func() {
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{
+					Command: `gh pr create --title "${PR_TITLE}" --body "$(cat <<'EOF'
+# PR Title
+
+## Motivation
+
+New feature description
+
+## Implementation information
+
+- Added endpoint
+- Updated documentation
+
+## Supporting documentation
+
+See docs/api.md
+EOF
+)"`,
+				},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeTrue())
+		})
+
+		It("should pass with a bare variable body", func() {
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{
+					Command: `gh pr create --title "feat(api): add endpoint" --body "$BODY"`,
+				},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeTrue())
+		})
+
+		It("should pass when both title and body are variables", func() {
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{
+					Command: `gh pr create --title "$TITLE" --body "$BODY"`,
+				},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeTrue())
+		})
+
 		It("should pass for non-gh commands", func() {
 			ctx := &hook.Context{
 				EventType: hook.EventTypePreToolUse,

--- a/internal/validators/git/pr_test.go
+++ b/internal/validators/git/pr_test.go
@@ -1153,6 +1153,22 @@ EOF
 			Expect(result.Passed).To(BeFalse())
 		})
 
+		It("should not run content checks on a command-substitution title", func() {
+			// A "$(...)" title is an unresolved expansion; the raw token must not
+			// be pattern-matched (it contains "tmp/" here) because the runtime
+			// value is unknown.
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{
+					Command: `gh pr create --title "$(make-title tmp/x)" --body "$BODY"`,
+				},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeTrue())
+		})
+
 		It("should pass for non-gh commands", func() {
 			ctx := &hook.Context{
 				EventType: hook.EventTypePreToolUse,

--- a/internal/validators/git/pr_test.go
+++ b/internal/validators/git/pr_test.go
@@ -1109,6 +1109,50 @@ EOF
 			Expect(result.Passed).To(BeTrue())
 		})
 
+		It("should still validate a single-quoted literal title", func() {
+			// Single quotes are literal in shell, so '$TITLE' is the literal
+			// string "$TITLE" and must be validated (and rejected), not skipped.
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{
+					Command: `gh pr create --title '$TITLE' --body "$(cat <<'EOF'
+# PR Title
+
+## Motivation
+
+New feature description
+
+## Implementation information
+
+- Added endpoint
+- Updated documentation
+
+## Supporting documentation
+
+See docs/api.md
+EOF
+)"`,
+				},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeFalse())
+		})
+
+		It("should still validate a single-quoted literal body", func() {
+			ctx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeBash,
+				ToolInput: hook.ToolInput{
+					Command: `gh pr create --title "feat(api): add endpoint" --body '$BODY'`,
+				},
+			}
+
+			result := validator.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeFalse())
+		})
+
 		It("should pass for non-gh commands", func() {
 			ctx := &hook.Context{
 				EventType: hook.EventTypePreToolUse,


### PR DESCRIPTION
## Motivation

The PR validator (GIT023) reads the title and body from the raw `gh pr create` command text with regex, so an unresolved shell variable appears verbatim. `gh pr create --title "$TITLE"` was rejected for not matching the conventional commits format, and `--body "$BODY"` for missing required sections, even though the real values are only known at runtime. This mirrors the bare-variable handling the commit, push, and branch validators already have.

## Implementation information

Skip title and body validation when the extracted value is a single shell expansion: `$NAME`, `${NAME}`, or a `$(...)` command substitution. The new `isBarePRExpansion` helper reuses `isBareExpansion` for the braced form and adds the short and command-substitution forms, since the regex extraction sees the raw source text rather than the parsed AST. Literal titles and bodies are still validated.

Tests cover a bare `$TITLE`, a braced `${TITLE}`, a bare `$BODY`, both being variables, and the existing literal-title rejection as a control.

## Supporting documentation

Reuses `isBareExpansion` from the commit validator; the short and `$(...)` forms are PR-specific because the title and body are extracted from raw command text.