### PR TITLE
feat(validator): flag filler comments that restate code

### DIFF
--- a/docs/errors/FILE011.md
+++ b/docs/errors/FILE011.md
@@ -1,0 +1,78 @@
+# FILE011: Filler comment detected
+
+## Error
+
+Code being written or edited contains a comment that only restates the line
+it annotates (e.g., `// Initialize the counter`, `// Loop through items`,
+`// Return the result`).
+
+## Why this matters
+
+Filler comments narrate *what* the code does instead of *why* it does it.
+Well-named identifiers already communicate the "what"; a comment repeating it
+adds noise without adding information, and rots the moment the code changes
+underneath it. This pattern is common in LLM-generated code and is disabled
+by default — enable it if you want klaudiush to push back on it.
+
+## How to fix
+
+Remove the comment, or replace it with one that explains a non-obvious
+reason:
+
+```go
+// Instead of:
+// Initialize the counter
+count := 0
+
+// Fix: remove it, or explain the why
+count := 0 // starts at zero to match the 1-indexed API offset
+```
+
+## Detected patterns
+
+klaudiush flags common throat-clearing phrases behind `//` or `#`:
+
+- Initialize/initializing
+- Loop/iterate through/over
+- Check if
+- Return(s/ing) the
+- Create(s) a new
+- Set(s) the
+- Increment/decrement
+- Call(s) the
+- Get(s) the
+- "This function/method/class does/is/handles/will"
+
+## Configuration
+
+Disabled by default. Enable it and optionally override the pattern list:
+
+```toml
+[validators.file.ai_comments]
+enabled = true
+patterns = []   # custom patterns (overrides defaults when set)
+```
+
+Disable the validator:
+
+```toml
+[validators.file.ai_comments]
+enabled = false
+```
+
+## Hook output
+
+When this error is triggered, klaudiush writes JSON to stdout:
+
+**permissionDecisionReason** (shown to Claude):
+`[FILE011] Filler comments that only restate the code are not allowed. Remove the comment or replace it with one that explains why, not what`
+
+**systemMessage** (shown to user):
+Formatted error with fix hint and reference URL.
+
+**additionalContext** (behavioral guidance):
+`Automated klaudiush validation check. Fix the reported errors and retry the same command.`
+
+## Related
+
+- [FILE010](FILE010.md) - linter ignore directives

--- a/internal/config/factory/file_factory.go
+++ b/internal/config/factory/file_factory.go
@@ -35,6 +35,13 @@ func (f *FileValidatorFactory) SetRuleEngine(engine *rules.RuleEngine) {
 	f.ruleEngine = engine
 }
 
+// fileValidatorCheck pairs an enablement condition with the validator it creates.
+type fileValidatorCheck struct {
+	enabled bool
+	key     string
+	create  func() ValidatorWithPredicate
+}
+
 // CreateValidators creates all file validators based on configuration.
 func (f *FileValidatorFactory) CreateValidators(cfg *config.Config) []ValidatorWithPredicate {
 	var validators []ValidatorWithPredicate
@@ -45,8 +52,22 @@ func (f *FileValidatorFactory) CreateValidators(cfg *config.Config) []ValidatorW
 		timeout = cfg.Global.DefaultTimeout.ToDuration()
 	}
 
-	// Initialize linters
 	runner := execpkg.NewCommandRunner(timeout)
+
+	for _, c := range f.fileValidatorChecks(cfg, runner) {
+		if c.enabled && !isValidatorOverridden(cfg.Overrides, c.key) {
+			validators = append(validators, c.create())
+		}
+	}
+
+	return validators
+}
+
+// fileValidatorChecks builds the enablement/factory pairs for every file validator.
+func (f *FileValidatorFactory) fileValidatorChecks(
+	cfg *config.Config,
+	runner execpkg.CommandRunner,
+) []fileValidatorCheck {
 	shellChecker := linters.NewShellChecker(runner)
 	terraformFormatter := linters.NewTerraformFormatter(runner)
 	tfLinter := linters.NewTfLinter(runner)
@@ -56,81 +77,85 @@ func (f *FileValidatorFactory) CreateValidators(cfg *config.Config) []ValidatorW
 	oxlintChecker := linters.NewOxlintChecker(runner)
 	rustfmtChecker := linters.NewRustfmtChecker(runner)
 
-	if cfg.Validators.File.Markdown != nil && cfg.Validators.File.Markdown.IsEnabled() &&
-		!isValidatorOverridden(cfg.Overrides, "file.markdown") {
-		// Create markdown linter with config for rule support
-		markdownLinter := linters.NewMarkdownLinterWithConfig(runner, cfg.Validators.File.Markdown)
+	fc := cfg.Validators.File
 
-		validators = append(
-			validators,
-			f.createMarkdownValidator(cfg.Validators.File.Markdown, markdownLinter),
-		)
+	return []fileValidatorCheck{
+		{
+			enabled: fc.Markdown != nil && fc.Markdown.IsEnabled(),
+			key:     "file.markdown",
+			create: func() ValidatorWithPredicate {
+				markdownLinter := linters.NewMarkdownLinterWithConfig(runner, fc.Markdown)
+				return f.createMarkdownValidator(fc.Markdown, markdownLinter)
+			},
+		},
+		{
+			enabled: fc.Terraform != nil && fc.Terraform.IsEnabled(),
+			key:     "file.terraform",
+			create: func() ValidatorWithPredicate {
+				return f.createTerraformValidator(fc.Terraform, terraformFormatter, tfLinter)
+			},
+		},
+		{
+			enabled: fc.ShellScript != nil && fc.ShellScript.IsEnabled(),
+			key:     "file.shellscript",
+			create: func() ValidatorWithPredicate {
+				return f.createShellScriptValidator(fc.ShellScript, shellChecker)
+			},
+		},
+		{
+			enabled: fc.Workflow != nil && fc.Workflow.IsEnabled(),
+			key:     "file.workflow",
+			create: func() ValidatorWithPredicate {
+				return f.createWorkflowValidator(
+					fc.Workflow,
+					actionLinter,
+					func() githubpkg.Client { return githubpkg.NewClient() },
+				)
+			},
+		},
+		{
+			enabled: fc.Gofumpt != nil && fc.Gofumpt.IsEnabled(),
+			key:     "file.gofumpt",
+			create: func() ValidatorWithPredicate {
+				return f.createGofumptValidator(fc.Gofumpt, gofumptChecker)
+			},
+		},
+		{
+			enabled: fc.Python != nil && fc.Python.IsEnabled(),
+			key:     "file.python",
+			create: func() ValidatorWithPredicate {
+				return f.createPythonValidator(fc.Python, ruffChecker)
+			},
+		},
+		{
+			enabled: fc.JavaScript != nil && fc.JavaScript.IsEnabled(),
+			key:     "file.javascript",
+			create: func() ValidatorWithPredicate {
+				return f.createJavaScriptValidator(fc.JavaScript, oxlintChecker)
+			},
+		},
+		{
+			enabled: fc.Rust != nil && fc.Rust.IsEnabled(),
+			key:     "file.rust",
+			create: func() ValidatorWithPredicate {
+				return f.createRustValidator(fc.Rust, rustfmtChecker)
+			},
+		},
+		{
+			enabled: fc.LinterIgnore != nil && fc.LinterIgnore.IsEnabled(),
+			key:     "file.linter_ignore",
+			create: func() ValidatorWithPredicate {
+				return f.createLinterIgnoreValidator(fc.LinterIgnore)
+			},
+		},
+		{
+			enabled: fc.AIComments != nil && fc.AIComments.IsEnabled(),
+			key:     "file.ai_comments",
+			create: func() ValidatorWithPredicate {
+				return f.createAICommentValidator(fc.AIComments)
+			},
+		},
 	}
-
-	if cfg.Validators.File.Terraform != nil && cfg.Validators.File.Terraform.IsEnabled() &&
-		!isValidatorOverridden(cfg.Overrides, "file.terraform") {
-		validators = append(validators, f.createTerraformValidator(
-			cfg.Validators.File.Terraform, terraformFormatter, tfLinter))
-	}
-
-	if cfg.Validators.File.ShellScript != nil && cfg.Validators.File.ShellScript.IsEnabled() &&
-		!isValidatorOverridden(cfg.Overrides, "file.shellscript") {
-		validators = append(
-			validators,
-			f.createShellScriptValidator(cfg.Validators.File.ShellScript, shellChecker),
-		)
-	}
-
-	if cfg.Validators.File.Workflow != nil && cfg.Validators.File.Workflow.IsEnabled() &&
-		!isValidatorOverridden(cfg.Overrides, "file.workflow") {
-		validators = append(validators, f.createWorkflowValidator(
-			cfg.Validators.File.Workflow,
-			actionLinter,
-			func() githubpkg.Client { return githubpkg.NewClient() },
-		))
-	}
-
-	if cfg.Validators.File.Gofumpt != nil && cfg.Validators.File.Gofumpt.IsEnabled() &&
-		!isValidatorOverridden(cfg.Overrides, "file.gofumpt") {
-		validators = append(
-			validators,
-			f.createGofumptValidator(cfg.Validators.File.Gofumpt, gofumptChecker),
-		)
-	}
-
-	if cfg.Validators.File.Python != nil && cfg.Validators.File.Python.IsEnabled() &&
-		!isValidatorOverridden(cfg.Overrides, "file.python") {
-		validators = append(
-			validators,
-			f.createPythonValidator(cfg.Validators.File.Python, ruffChecker),
-		)
-	}
-
-	if cfg.Validators.File.JavaScript != nil && cfg.Validators.File.JavaScript.IsEnabled() &&
-		!isValidatorOverridden(cfg.Overrides, "file.javascript") {
-		validators = append(
-			validators,
-			f.createJavaScriptValidator(cfg.Validators.File.JavaScript, oxlintChecker),
-		)
-	}
-
-	if cfg.Validators.File.Rust != nil && cfg.Validators.File.Rust.IsEnabled() &&
-		!isValidatorOverridden(cfg.Overrides, "file.rust") {
-		validators = append(
-			validators,
-			f.createRustValidator(cfg.Validators.File.Rust, rustfmtChecker),
-		)
-	}
-
-	if cfg.Validators.File.LinterIgnore != nil && cfg.Validators.File.LinterIgnore.IsEnabled() &&
-		!isValidatorOverridden(cfg.Overrides, "file.linter_ignore") {
-		validators = append(
-			validators,
-			f.createLinterIgnoreValidator(cfg.Validators.File.LinterIgnore),
-		)
-	}
-
-	return validators
 }
 
 func (f *FileValidatorFactory) createMarkdownValidator(
@@ -379,6 +404,30 @@ func (f *FileValidatorFactory) createLinterIgnoreValidator(
 	return ValidatorWithPredicate{
 		Validator: wrapValidatorWithSeverity(
 			filevalidators.NewLinterIgnoreValidator(f.log, cfg, rc),
+			cfg,
+		),
+		Predicate: validator.And(
+			beforeToolOrCodexAfterToolPredicate(),
+			validator.ToolTypeIn(hook.ToolTypeWrite, hook.ToolTypeEdit, hook.ToolTypeMultiEdit),
+		),
+	}
+}
+
+func (f *FileValidatorFactory) createAICommentValidator(
+	cfg *config.AICommentValidatorConfig,
+) ValidatorWithPredicate {
+	var rc validator.RuleChecker
+	if f.ruleEngine != nil {
+		rc = rules.NewRuleValidatorAdapter(
+			f.ruleEngine,
+			rules.ValidatorFileAIComments,
+			rules.WithAdapterLogger(f.log),
+		)
+	}
+
+	return ValidatorWithPredicate{
+		Validator: wrapValidatorWithSeverity(
+			filevalidators.NewAICommentValidator(f.log, cfg, rc),
 			cfg,
 		),
 		Predicate: validator.And(

--- a/internal/rules/types.go
+++ b/internal/rules/types.go
@@ -50,6 +50,7 @@ const (
 	ValidatorFileJavaScript   ValidatorType = "file.javascript"
 	ValidatorFileRust         ValidatorType = "file.rust"
 	ValidatorFileLinterIgnore ValidatorType = "file.linter_ignore"
+	ValidatorFileAIComments   ValidatorType = "file.ai_comments"
 	ValidatorFileAll          ValidatorType = "file.*"
 	ValidatorSecrets          ValidatorType = "secrets.secrets"
 	ValidatorShellBacktick    ValidatorType = "shell.backtick"

--- a/internal/validator/reference.go
+++ b/internal/validator/reference.go
@@ -90,7 +90,7 @@ const (
 	RefGitBlockedBranch Reference = ReferenceBaseURL + "/GIT026"
 )
 
-// File-related references (FILE001-FILE009).
+// File-related references (FILE001-FILE011).
 const (
 	// RefShellcheck indicates shellcheck validation failure.
 	RefShellcheck Reference = ReferenceBaseURL + "/FILE001"
@@ -121,6 +121,9 @@ const (
 
 	// RefLinterIgnore indicates linter ignore directives detected in code.
 	RefLinterIgnore Reference = ReferenceBaseURL + "/FILE010"
+
+	// RefAIComments indicates filler comments that only restate adjacent code.
+	RefAIComments Reference = ReferenceBaseURL + "/FILE011"
 )
 
 // Security-related references (SEC001-SEC005).

--- a/internal/validator/suggestions.go
+++ b/internal/validator/suggestions.go
@@ -44,6 +44,7 @@ var DefaultSuggestions = map[Reference]string{
 	RefOxlintCheck:  "Run 'oxlint <file>' to see JavaScript/TypeScript code quality issues",
 	RefRustfmtCheck: "Run 'rustfmt <file>' to auto-fix formatting",
 	RefLinterIgnore: "Fix linter errors properly instead of suppressing them with ignore directives",
+	RefAIComments:   "Remove the comment or replace it with one that explains why, not what",
 
 	// Security suggestions
 	RefSecretsAPIKey:     "Remove API key and use environment variables or secret management",

--- a/internal/validators/file/ai_comments.go
+++ b/internal/validators/file/ai_comments.go
@@ -1,0 +1,81 @@
+package file
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/smykla-skalski/klaudiush/internal/validator"
+	"github.com/smykla-skalski/klaudiush/pkg/config"
+	"github.com/smykla-skalski/klaudiush/pkg/hook"
+	"github.com/smykla-skalski/klaudiush/pkg/logger"
+)
+
+// defaultAICommentPatterns match filler comments that only restate the line
+// of code they annotate, a pattern common in LLM-generated output. Each
+// pattern matches a "//" or "#" comment marker followed by a throat-clearing
+// phrase; comments explaining *why* rarely open this way.
+var defaultAICommentPatterns = []string{
+	`(?i)(//|#)\s*initiali[sz](e|ing)\s`,
+	`(?i)(//|#)\s*(loop|iterate)(s|ing)?\s+(through|over)\b`,
+	`(?i)(//|#)\s*check(s|ing)?\s+if\b`,
+	`(?i)(//|#)\s*returns?(ing)?\s+the\b`,
+	`(?i)(//|#)\s*creates?(ing)?\s+a\s+new\b`,
+	`(?i)(//|#)\s*sets?(ting)?\s+the\b`,
+	`(?i)(//|#)\s*(increment|decrement)(s|ing)?\s+the\b`,
+	`(?i)(//|#)\s*calls?(ing)?\s+the\b`,
+	`(?i)(//|#)\s*gets?(ting)?\s+the\b`,
+	`(?i)(//|#)\s*(this function|this method|this class)\s+(does|is|handles|will)\b`,
+}
+
+// AICommentValidator flags filler comments that only restate adjacent code,
+// a pattern common in LLM-generated output.
+type AICommentValidator struct {
+	validator.BaseValidator
+	config   *config.AICommentValidatorConfig
+	patterns []*regexp.Regexp
+}
+
+// NewAICommentValidator creates a new AICommentValidator.
+func NewAICommentValidator(
+	log logger.Logger,
+	cfg *config.AICommentValidatorConfig,
+	ruleAdapter validator.RuleChecker,
+) *AICommentValidator {
+	v := &AICommentValidator{
+		BaseValidator: *validator.NewBaseValidatorWithRules("validate-ai-comments", log, ruleAdapter),
+		config:        cfg,
+	}
+
+	v.patterns = compilePatterns(log, "AI comment", v.getPatterns())
+
+	return v
+}
+
+// aiCommentHeader is the message header shown when a filler comment is blocked.
+const aiCommentHeader = "Filler comments that only restate the code are not allowed"
+
+// Validate checks for filler comments that restate adjacent code.
+func (v *AICommentValidator) Validate(
+	ctx context.Context,
+	hookCtx *hook.Context,
+) *validator.Result {
+	return validatePatterns(
+		ctx, hookCtx, v.CheckRules, v.patterns,
+		aiCommentHeader, validator.RefAIComments,
+	)
+}
+
+// getPatterns returns the configured patterns or defaults.
+func (v *AICommentValidator) getPatterns() []string {
+	if v.config != nil && len(v.config.Patterns) > 0 {
+		return v.config.Patterns
+	}
+
+	return defaultAICommentPatterns
+}
+
+// Category returns the validator category for parallel execution.
+// AICommentValidator uses CategoryCPU because it only does pattern matching.
+func (*AICommentValidator) Category() validator.ValidatorCategory {
+	return validator.CategoryCPU
+}

--- a/internal/validators/file/ai_comments_test.go
+++ b/internal/validators/file/ai_comments_test.go
@@ -1,0 +1,203 @@
+package file_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/smykla-skalski/klaudiush/internal/validator"
+	"github.com/smykla-skalski/klaudiush/internal/validators/file"
+	"github.com/smykla-skalski/klaudiush/pkg/config"
+	"github.com/smykla-skalski/klaudiush/pkg/hook"
+	"github.com/smykla-skalski/klaudiush/pkg/logger"
+)
+
+var _ = Describe("AICommentValidator", func() {
+	var (
+		v   *file.AICommentValidator
+		ctx *hook.Context
+	)
+
+	BeforeEach(func() {
+		v = file.NewAICommentValidator(logger.NewNoOpLogger(), nil, nil)
+		ctx = &hook.Context{
+			EventType: hook.EventTypePreToolUse,
+			ToolName:  hook.ToolTypeWrite,
+		}
+	})
+
+	Describe("Name", func() {
+		It("returns correct validator name", func() {
+			Expect(v.Name()).To(Equal("validate-ai-comments"))
+		})
+	})
+
+	Describe("Category", func() {
+		It("returns CategoryCPU", func() {
+			Expect(v.Category()).To(Equal(validator.CategoryCPU))
+		})
+	})
+
+	Describe("NewAICommentValidator", func() {
+		It("handles invalid regex patterns gracefully", func() {
+			cfg := &config.AICommentValidatorConfig{
+				Patterns: []string{
+					`valid-pattern`,
+					`[invalid(regex`, // Invalid regex
+					`another-valid`,
+				},
+			}
+
+			validator := file.NewAICommentValidator(logger.NewNoOpLogger(), cfg, nil)
+			Expect(validator).NotTo(BeNil())
+		})
+
+		It("uses default patterns when config is nil", func() {
+			validator := file.NewAICommentValidator(logger.NewNoOpLogger(), nil, nil)
+			Expect(validator).NotTo(BeNil())
+		})
+
+		It("uses custom patterns from config", func() {
+			cfg := &config.AICommentValidatorConfig{
+				Patterns: []string{`// custom-filler`},
+			}
+
+			validator := file.NewAICommentValidator(logger.NewNoOpLogger(), cfg, nil)
+			testCtx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeWrite,
+				ToolInput: hook.ToolInput{
+					Content: `x := 1 // custom-filler`,
+				},
+			}
+
+			result := validator.Validate(context.Background(), testCtx)
+			Expect(result.Passed).To(BeFalse())
+		})
+
+		It("uses default patterns when config has empty patterns", func() {
+			cfg := &config.AICommentValidatorConfig{
+				Patterns: []string{},
+			}
+
+			validator := file.NewAICommentValidator(logger.NewNoOpLogger(), cfg, nil)
+			testCtx := &hook.Context{
+				EventType: hook.EventTypePreToolUse,
+				ToolName:  hook.ToolTypeWrite,
+				ToolInput: hook.ToolInput{
+					Content: `// Initialize the counter
+count := 0`,
+				},
+			}
+
+			result := validator.Validate(context.Background(), testCtx)
+			Expect(result.Passed).To(BeFalse())
+		})
+	})
+
+	Describe("Validate", func() {
+		Context("with clean code", func() {
+			It("passes for code with no filler comments", func() {
+				ctx.ToolInput.Content = `
+// ExecuteQuery runs against a read replica to avoid write-path lock contention.
+func ExecuteQuery() {}
+`
+				result := v.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeTrue())
+			})
+
+			It("passes for empty content", func() {
+				ctx.ToolInput.Content = ""
+				result := v.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeTrue())
+			})
+		})
+
+		Context("filler comment phrases", func() {
+			It("fails for 'Initialize the'", func() {
+				ctx.ToolInput.Content = `
+// Initialize the counter
+count := 0
+`
+				result := v.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeFalse())
+				Expect(result.ShouldBlock).To(BeTrue())
+				Expect(
+					result.Message,
+				).To(ContainSubstring("Filler comments that only restate the code are not allowed"))
+			})
+
+			It("fails for 'Loop through'", func() {
+				ctx.ToolInput.Content = `// Loop through the items
+for _, item := range items {}`
+				result := v.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeFalse())
+			})
+
+			It("fails for 'Check if'", func() {
+				ctx.ToolInput.Content = `# Check if the value is set
+if value:
+    pass`
+				result := v.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeFalse())
+			})
+
+			It("fails for 'Return the'", func() {
+				ctx.ToolInput.Content = `// Return the result
+return result`
+				result := v.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeFalse())
+			})
+
+			It("fails for 'Create a new'", func() {
+				ctx.ToolInput.Content = "// Create a new session\nsess := Session{}"
+				result := v.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeFalse())
+			})
+
+			It("fails for 'This function'", func() {
+				ctx.ToolInput.Content = `// This function does the calculation
+func calc() {}`
+				result := v.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeFalse())
+			})
+		})
+
+		Context("Edit operations", func() {
+			BeforeEach(func() {
+				ctx.ToolName = hook.ToolTypeEdit
+			})
+
+			It("checks new_string content", func() {
+				ctx.ToolInput.OldString = `count := 0`
+				ctx.ToolInput.NewString = "// Initialize the counter\ncount := 0"
+				result := v.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeFalse())
+			})
+
+			It("passes when new_string is clean", func() {
+				ctx.ToolInput.OldString = "// Initialize the counter\ncount := 0"
+				ctx.ToolInput.NewString = `count := 0`
+				result := v.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeTrue())
+			})
+		})
+
+		Context("error reference", func() {
+			It("includes FILE011 reference", func() {
+				ctx.ToolInput.Content = `// Initialize the counter`
+				result := v.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeFalse())
+				Expect(string(result.Reference)).To(Equal("https://klaudiu.sh/e/FILE011"))
+			})
+
+			It("includes fix hint", func() {
+				ctx.ToolInput.Content = `// Initialize the counter`
+				result := v.Validate(context.Background(), ctx)
+				Expect(result.Passed).To(BeFalse())
+				Expect(result.FixHint).To(ContainSubstring("explains why, not what"))
+			})
+		})
+	})
+})

--- a/internal/validators/file/linter_ignore.go
+++ b/internal/validators/file/linter_ignore.go
@@ -2,9 +2,7 @@ package file
 
 import (
 	"context"
-	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/smykla-skalski/klaudiush/internal/validator"
 	"github.com/smykla-skalski/klaudiush/pkg/config"
@@ -76,24 +74,7 @@ func NewLinterIgnoreValidator(
 		config:        cfg,
 	}
 
-	// Compile patterns
-	patterns := v.getPatterns()
-	v.patterns = make([]*regexp.Regexp, 0, len(patterns))
-
-	for _, pattern := range patterns {
-		re, err := regexp.Compile(pattern)
-		if err != nil {
-			log.Error("failed to compile linter ignore pattern", "pattern", pattern, "error", err)
-			continue
-		}
-
-		v.patterns = append(v.patterns, re)
-	}
-
-	// Log error when zero patterns compiled (will pass all content)
-	if len(v.patterns) == 0 && len(patterns) > 0 {
-		log.Error("all linter ignore patterns failed to compile", "total", len(patterns))
-	}
+	v.patterns = compilePatterns(log, "linter ignore", v.getPatterns())
 
 	return v
 }
@@ -103,95 +84,10 @@ func (v *LinterIgnoreValidator) Validate(
 	ctx context.Context,
 	hookCtx *hook.Context,
 ) *validator.Result {
-	log := v.Logger()
-	log.Debug("validating for linter ignore directives")
-
-	// Check rules first
-	if result := v.CheckRules(ctx, hookCtx); result != nil {
-		return result
-	}
-
-	// Get content from context
-	content := v.getContent(hookCtx)
-
-	if content == "" {
-		log.Debug("no content to validate")
-		return validator.Pass()
-	}
-
-	// Check for ignore directives
-	violations := v.findViolations(content)
-	if len(violations) == 0 {
-		log.Debug("no linter ignore directives found")
-		return validator.Pass()
-	}
-
-	// Build error message
-	message := v.formatViolations(violations)
-
-	return validator.FailWithRef(validator.RefLinterIgnore, message)
-}
-
-// getContent extracts content from hook context.
-func (*LinterIgnoreValidator) getContent(hookCtx *hook.Context) string {
-	// For Write operations, get content directly
-	if hookCtx.ToolInput.Content != "" {
-		return hookCtx.ToolInput.Content
-	}
-
-	// For Edit operations, check new string
-	if hookCtx.ToolName == hook.ToolTypeEdit {
-		newStr := hookCtx.ToolInput.NewString
-
-		// We need to check the new content being added
-		if newStr != "" {
-			return newStr
-		}
-
-		// If new string is empty, no content to validate
-		return ""
-	}
-
-	return ""
-}
-
-// findViolations searches for linter ignore directive patterns in content.
-func (v *LinterIgnoreValidator) findViolations(content string) []violation {
-	var violations []violation
-
-	lines := strings.Split(content, "\n")
-
-	for lineNum, line := range lines {
-		for _, pattern := range v.patterns {
-			if match := pattern.FindString(line); match != "" {
-				violations = append(violations, violation{
-					line:      lineNum + 1,
-					directive: strings.TrimSpace(match),
-				})
-
-				break // Only report first match per line
-			}
-		}
-	}
-
-	return violations
-}
-
-// formatViolations formats violation findings into error message.
-func (*LinterIgnoreValidator) formatViolations(violations []violation) string {
-	var sb strings.Builder
-
-	fmt.Fprint(&sb, "Linter ignore directives are not allowed\n\n")
-
-	for i, v := range violations {
-		if i > 0 {
-			fmt.Fprint(&sb, "\n")
-		}
-
-		fmt.Fprintf(&sb, "Line %d: %s", v.line, v.directive)
-	}
-
-	return sb.String()
+	return validatePatterns(
+		ctx, hookCtx, v.CheckRules, v.patterns,
+		"Linter ignore directives are not allowed", validator.RefLinterIgnore,
+	)
 }
 
 // getPatterns returns the configured patterns or defaults.
@@ -207,10 +103,4 @@ func (v *LinterIgnoreValidator) getPatterns() []string {
 // LinterIgnoreValidator uses CategoryCPU because it only does pattern matching.
 func (*LinterIgnoreValidator) Category() validator.ValidatorCategory {
 	return validator.CategoryCPU
-}
-
-// violation represents a detected linter ignore directive.
-type violation struct {
-	line      int
-	directive string
 }

--- a/internal/validators/file/pattern_match.go
+++ b/internal/validators/file/pattern_match.go
@@ -1,0 +1,118 @@
+package file
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/smykla-skalski/klaudiush/internal/validator"
+	"github.com/smykla-skalski/klaudiush/pkg/hook"
+	"github.com/smykla-skalski/klaudiush/pkg/logger"
+)
+
+// violation represents a line matching one of a validator's patterns.
+type violation struct {
+	line      int
+	directive string
+}
+
+// compilePatterns compiles the given regex patterns, logging and skipping any that fail.
+func compilePatterns(log logger.Logger, label string, patterns []string) []*regexp.Regexp {
+	compiled := make([]*regexp.Regexp, 0, len(patterns))
+
+	for _, pattern := range patterns {
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			log.Error("failed to compile "+label+" pattern", "pattern", pattern, "error", err)
+			continue
+		}
+
+		compiled = append(compiled, re)
+	}
+
+	if len(compiled) == 0 && len(patterns) > 0 {
+		log.Error("all "+label+" patterns failed to compile", "total", len(patterns))
+	}
+
+	return compiled
+}
+
+// findPatternViolations returns each line matching any pattern, one match per line.
+func findPatternViolations(content string, patterns []*regexp.Regexp) []violation {
+	var violations []violation
+
+	lines := strings.Split(content, "\n")
+
+	for lineNum, line := range lines {
+		for _, pattern := range patterns {
+			if match := pattern.FindString(line); match != "" {
+				violations = append(violations, violation{
+					line:      lineNum + 1,
+					directive: strings.TrimSpace(match),
+				})
+
+				break // Only report first match per line
+			}
+		}
+	}
+
+	return violations
+}
+
+// formatPatternViolations renders violations under the given message header.
+func formatPatternViolations(header string, violations []violation) string {
+	var sb strings.Builder
+
+	fmt.Fprintf(&sb, "%s\n\n", header)
+
+	for i, v := range violations {
+		if i > 0 {
+			fmt.Fprint(&sb, "\n")
+		}
+
+		fmt.Fprintf(&sb, "Line %d: %s", v.line, v.directive)
+	}
+
+	return sb.String()
+}
+
+// getWriteOrEditContent extracts the new content from a Write or Edit hook context.
+func getWriteOrEditContent(hookCtx *hook.Context) string {
+	if hookCtx.ToolInput.Content != "" {
+		return hookCtx.ToolInput.Content
+	}
+
+	if hookCtx.ToolName == hook.ToolTypeEdit {
+		return hookCtx.ToolInput.NewString
+	}
+
+	return ""
+}
+
+// validatePatterns runs the shared rule-check → extract → match → report flow
+// used by pattern-based file validators.
+func validatePatterns(
+	ctx context.Context,
+	hookCtx *hook.Context,
+	checkRules func(context.Context, *hook.Context) *validator.Result,
+	patterns []*regexp.Regexp,
+	header string,
+	ref validator.Reference,
+) *validator.Result {
+	if result := checkRules(ctx, hookCtx); result != nil {
+		return result
+	}
+
+	content := getWriteOrEditContent(hookCtx)
+	if content == "" {
+		return validator.Pass()
+	}
+
+	violations := findPatternViolations(content, patterns)
+	if len(violations) == 0 {
+		return validator.Pass()
+	}
+
+	return validator.FailWithRef(ref, formatPatternViolations(header, violations))
+}

--- a/pkg/config/file.go
+++ b/pkg/config/file.go
@@ -29,6 +29,9 @@ type FileConfig struct {
 
 	// LinterIgnore validator configuration
 	LinterIgnore *LinterIgnoreValidatorConfig `json:"linter_ignore,omitempty" koanf:"linter_ignore" toml:"linter_ignore,omitempty"`
+
+	// AIComments validator configuration
+	AIComments *AICommentValidatorConfig `json:"ai_comments,omitempty" koanf:"ai_comments" toml:"ai_comments,omitempty"`
 }
 
 // MarkdownValidatorConfig configures the Markdown file validator.
@@ -338,5 +341,14 @@ type LinterIgnoreValidatorConfig struct {
 
 	// Patterns is a list of regex patterns to detect linter ignore directives.
 	// Default: built-in patterns for common languages (noqa, eslint-disable, nolint, etc.)
+	Patterns []string `json:"patterns,omitempty" koanf:"patterns" toml:"patterns,omitempty"`
+}
+
+// AICommentValidatorConfig configures the AI filler comment validator.
+type AICommentValidatorConfig struct {
+	ValidatorConfig `koanf:",squash"`
+
+	// Patterns is a list of regex patterns to detect filler comments.
+	// Default: built-in patterns for throat-clearing phrases (initialize, loop through, etc.)
 	Patterns []string `json:"patterns,omitempty" koanf:"patterns" toml:"patterns,omitempty"`
 }

--- a/schema/config.v1.schema.json
+++ b/schema/config.v1.schema.json
@@ -2,6 +2,27 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/smykla-skalski/klaudiush/pkg/config/config",
   "$defs": {
+    "AICommentValidatorConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "severity": {
+          "$ref": "#/$defs/Severity"
+        },
+        "rules_enabled": {
+          "type": "boolean"
+        },
+        "patterns": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "AddValidatorConfig": {
       "properties": {
         "enabled": {
@@ -458,6 +479,9 @@
         },
         "linter_ignore": {
           "$ref": "#/$defs/LinterIgnoreValidatorConfig"
+        },
+        "ai_comments": {
+          "$ref": "#/$defs/AICommentValidatorConfig"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## Motivation

> Changelog: feat(validator): flag filler comments that restate code

Claude Code and other LLM coding agents keep adding throat-clearing
comments ("Initialize the counter", "Loop through the items", "This
function does X") even when instructed not to. klaudiush already
blocks other code-quality anti-patterns at the hook layer (e.g.
FILE010 linter-ignore directives); this adds the same mechanism for
filler comments, since instruction-based suppression alone doesn't
reliably work.

## Implementation information

- New opt-in `FILE011` validator (`file.ai_comments`), disabled by
  default — same shape as the existing `LinterIgnoreValidator`
  (`file.linter_ignore`): regex pattern list, user-overridable.
- Wired through the existing factory/rules/reference/schema
  machinery (`internal/config/factory/file_factory.go`,
  `internal/rules/types.go`, `internal/validator/reference.go`,
  `internal/validator/suggestions.go`, `pkg/config/file.go`,
  `schema/config.v1.schema.json`).
- Extracted shared pattern-compile/match/format/validate logic
  (`internal/validators/file/pattern_match.go`) out of
  `LinterIgnoreValidator` and the new `AICommentValidator` to avoid
  duplicating the two nearly-identical validators.
- Also split `FileValidatorFactory.CreateValidators` into a
  `fileValidatorChecks` table to keep it under the linter's
  complexity/length limits after adding the 10th validator.
- Doc page: `docs/errors/FILE011.md`.

Enable it via:

```toml
[validators.file.ai_comments]
enabled = true
```

## Supporting documentation

- Sibling implementation: `internal/validators/file/linter_ignore.go` (FILE010)