### PR TITLE
feat(validator): broaden ai comment detection

### DIFF
--- a/docs/errors/FILE011.md
+++ b/docs/errors/FILE011.md
@@ -44,7 +44,7 @@ does/is/handles/...".
 ## Allowed (not flagged)
 
 - Task and annotation markers: `// TODO: ...`, `// FIXME ...`, `// HACK`,
-  `// XXX`, `// BUG`, `@annotations`.
+  `// XXX`, `// BUG`, `// OPTIMIZE`, `// REVIEW`, `// DEPRECATED`, `@annotations`.
 - Doc comments directly above an exported/public declaration (Go exported
   func/type/const/var, JS/TS `export`, Python `def`/`class`) — a blank line
   between the comment and the declaration breaks this exemption.

--- a/docs/errors/FILE011.md
+++ b/docs/errors/FILE011.md
@@ -2,17 +2,17 @@
 
 ## Error
 
-Code being written or edited contains a comment that only restates the line
-it annotates (e.g., `// Initialize the counter`, `// Loop through items`,
-`// Return the result`).
+Code being written or edited contains a comment that opens with an action
+verb narrating *what* the next line does (e.g., `// Initialize the counter`,
+`// Loop through items`, `// Return the result`, `// Configure the client`).
 
 ## Why this matters
 
-Filler comments narrate *what* the code does instead of *why* it does it.
+Filler comments restate *what* the code does instead of *why* it does it.
 Well-named identifiers already communicate the "what"; a comment repeating it
-adds noise without adding information, and rots the moment the code changes
-underneath it. This pattern is common in LLM-generated code and is disabled
-by default — enable it if you want klaudiush to push back on it.
+adds noise and rots the moment the code changes underneath it. This pattern is
+common in LLM-generated code. Idiomatic doc comments (which open with the
+identifier name) and "why" comments (which open with a reason) are unaffected.
 
 ## How to fix
 
@@ -30,22 +30,29 @@ count := 0 // starts at zero to match the 1-indexed API offset
 
 ## Detected patterns
 
-klaudiush flags common throat-clearing phrases behind `//` or `#`:
+A comment is flagged when it opens (behind `//` or `#`, optionally after
+`the`/`a`/`an`) with a code-restating verb: initialize, set, get, loop,
+iterate, check, return, create, make, build, call, invoke, execute, run,
+increment/decrement, add/append/insert/push, remove/delete/clear/pop,
+update/modify/change, handle, process, parse/format/convert, encode/decode,
+marshal/unmarshal, compute/calculate, assign/declare/define, configure,
+register, open/close/read/write, load/save/store, fetch/send/receive,
+wait/start/stop, print/log/emit, render/draw, filter/sort/find/search/count,
+validate/verify/ensure, and similar. Also caught: "This function/method/...
+does/is/handles/...".
 
-- Initialize/initializing
-- Loop/iterate through/over
-- Check if
-- Return(s/ing) the
-- Create(s) a new
-- Set(s) the
-- Increment/decrement
-- Call(s) the
-- Get(s) the
-- "This function/method/class does/is/handles/will"
+## Allowed (not flagged)
+
+- Task and annotation markers: `// TODO: ...`, `// FIXME ...`, `// HACK`,
+  `// XXX`, `// BUG`, `@annotations`.
+- Doc comments directly above an exported/public declaration (Go exported
+  func/type/const/var, JS/TS `export`, Python `def`/`class`) — a blank line
+  between the comment and the declaration breaks this exemption.
+- Any comment that does not open with a restating verb (e.g. a "why" comment).
 
 ## Configuration
 
-Disabled by default. Enable it and optionally override the pattern list:
+Enable it and optionally override the pattern list:
 
 ```toml
 [validators.file.ai_comments]

--- a/internal/validators/file/ai_comments.go
+++ b/internal/validators/file/ai_comments.go
@@ -3,6 +3,7 @@ package file
 import (
 	"context"
 	"regexp"
+	"strings"
 
 	"github.com/smykla-skalski/klaudiush/internal/validator"
 	"github.com/smykla-skalski/klaudiush/pkg/config"
@@ -10,22 +11,61 @@ import (
 	"github.com/smykla-skalski/klaudiush/pkg/logger"
 )
 
-// defaultAICommentPatterns match filler comments that only restate the line
-// of code they annotate, a pattern common in LLM-generated output. Each
-// pattern matches a "//" or "#" comment marker followed by a throat-clearing
-// phrase; comments explaining *why* rarely open this way.
+// defaultAICommentPatterns flag a comment that opens with an action verb that
+// merely restates the adjacent code — the dominant tell of LLM-generated
+// filler. Idiomatic doc comments open with the identifier name and useful
+// comments open with a reason ("why"), so neither trips these patterns; only
+// the "verb-first narration of what the next line does" style does.
 var defaultAICommentPatterns = []string{
-	`(?i)(//|#)\s*initiali[sz](e|ing)\s`,
-	`(?i)(//|#)\s*(loop|iterate)(s|ing)?\s+(through|over)\b`,
-	`(?i)(//|#)\s*check(s|ing)?\s+if\b`,
-	`(?i)(//|#)\s*returns?(ing)?\s+the\b`,
-	`(?i)(//|#)\s*creates?(ing)?\s+a\s+new\b`,
-	`(?i)(//|#)\s*sets?(ting)?\s+the\b`,
-	`(?i)(//|#)\s*(increment|decrement)(s|ing)?\s+the\b`,
-	`(?i)(//|#)\s*calls?(ing)?\s+the\b`,
-	`(?i)(//|#)\s*gets?(ting)?\s+the\b`,
-	`(?i)(//|#)\s*(this function|this method|this class)\s+(does|is|handles|will)\b`,
+	// A comment opening (optionally after "the"/"a") with a verb whose only
+	// job is to describe the mechanics of the following statement.
+	`(?i)(//|#)\s*(the\s+|a\s+|an\s+)?` +
+		`(initiali[sz]|set|reset|get|loop|iterate|check|return|` +
+		`creat|mak|build|construct|instantiat|` +
+		`call|invok|execut|run|increment|decrement|` +
+		`add|append|prepend|insert|push|` +
+		`remov|delet|clear|pop|drop|updat|modif|chang|` +
+		`handl|process|pars|format|convert|encod|decod|` +
+		`serializ|deserializ|marshal|unmarshal|comput|calculat|` +
+		`assign|declar|defin|configur|register|setup|` +
+		`open|clos|read|writ|load|sav|stor|fetch|send|receiv|` +
+		`wait|start|stop|begin|print|log|output|emit|dispatch|` +
+		`render|draw|filter|sort|find|search|count|` +
+		`validat|verif|ensur|sanitiz|normaliz|` +
+		`copy|mov|renam|split|join|trim|replac|compar|` +
+		`toggl|enabl|disabl|mark|lock|bind|connect)` +
+		`(e|es|ed|d|s|ing|ping|ting|ning|ling|ging|ies|ied|y)?\b`,
+	// "This function/method/... does/is/handles/..." restatements.
+	`(?i)(//|#)\s*this\s+(function|method|class|struct|interface|type|` +
+		`variable|field|constant|value|helper|wrapper)\s+` +
+		`(does|is|are|will|handles?|returns?|sets?|gets?|` +
+		`represents?|holds?|stores?|contains?)\b`,
 }
+
+// aiTodoMarker matches a comment that opens with a task or annotation marker.
+// These carry intent ("what still needs doing") rather than restating code and
+// are always allowed.
+var aiTodoMarker = regexp.MustCompile(
+	`(?i)^\s*(TODO|FIXME|HACK|XXX|BUG|WARNING|` +
+		`OPTIMI[SZ]E|REVIEW|DEPRECATED)\b|^\s*@\w+`,
+)
+
+// aiExportedDecl matches a source line that declares an exported/public symbol.
+// A leading comment block directly above such a line is its documentation and
+// is allowed even when it opens with a verb (Go requires doc comments on
+// exported identifiers).
+var aiExportedDecl = regexp.MustCompile(
+	`^\s*(` +
+		`func\s+(\([^)]*\)\s*)?[A-Z]` + // Go exported func or method
+		`|type\s+[A-Z]` + // Go exported type
+		`|(const|var)\s+[A-Z]` + // Go exported const/var
+		`|export\b` + // JS/TS export
+		`|(async\s+)?(def|class)\s+[A-Za-z]` + // Python def/class (public: no leading _)
+		`)`,
+)
+
+// aiCommentMarker locates the start of a // or # comment on a line.
+var aiCommentMarker = regexp.MustCompile(`(//|#)`)
 
 // AICommentValidator flags filler comments that only restate adjacent code,
 // a pattern common in LLM-generated output.
@@ -54,15 +94,95 @@ func NewAICommentValidator(
 // aiCommentHeader is the message header shown when a filler comment is blocked.
 const aiCommentHeader = "Filler comments that only restate the code are not allowed"
 
-// Validate checks for filler comments that restate adjacent code.
+// Validate checks for filler comments that restate adjacent code, allowing
+// task markers and doc comments on exported declarations.
 func (v *AICommentValidator) Validate(
 	ctx context.Context,
 	hookCtx *hook.Context,
 ) *validator.Result {
-	return validatePatterns(
-		ctx, hookCtx, v.CheckRules, v.patterns,
-		aiCommentHeader, validator.RefAIComments,
+	if result := v.CheckRules(ctx, hookCtx); result != nil {
+		return result
+	}
+
+	content := getWriteOrEditContent(hookCtx)
+	if content == "" {
+		return validator.Pass()
+	}
+
+	violations := findAICommentViolations(content, v.patterns)
+	if len(violations) == 0 {
+		return validator.Pass()
+	}
+
+	return validator.FailWithRef(
+		validator.RefAIComments,
+		formatPatternViolations(aiCommentHeader, violations),
 	)
+}
+
+// findAICommentViolations reports filler comments while exempting task markers
+// and documentation on exported declarations.
+func findAICommentViolations(content string, patterns []*regexp.Regexp) []violation {
+	var violations []violation
+
+	lines := strings.Split(content, "\n")
+
+	for i, line := range lines {
+		loc := aiCommentMarker.FindStringIndex(line)
+		if loc == nil {
+			continue
+		}
+
+		if aiTodoMarker.MatchString(line[loc[1]:]) {
+			continue
+		}
+
+		if isFullLineComment(line) && precedesExportedDecl(lines, i) {
+			continue
+		}
+
+		for _, pattern := range patterns {
+			if match := pattern.FindString(line); match != "" {
+				violations = append(violations, violation{
+					line:      i + 1,
+					directive: strings.TrimSpace(match),
+				})
+
+				break
+			}
+		}
+	}
+
+	return violations
+}
+
+// isFullLineComment reports whether the line is a standalone comment rather
+// than a trailing (inline) comment; only standalone comments can document a
+// declaration.
+func isFullLineComment(line string) bool {
+	trimmed := strings.TrimSpace(line)
+
+	return strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "#")
+}
+
+// precedesExportedDecl reports whether the comment at index i is part of a
+// leading comment block whose first non-comment line declares an exported
+// symbol. A blank line breaks the association (it is no longer a doc comment).
+func precedesExportedDecl(lines []string, i int) bool {
+	for j := i + 1; j < len(lines); j++ {
+		trimmed := strings.TrimSpace(lines[j])
+		if trimmed == "" {
+			return false
+		}
+
+		if strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		return aiExportedDecl.MatchString(lines[j])
+	}
+
+	return false
 }
 
 // getPatterns returns the configured patterns or defaults.

--- a/internal/validators/file/ai_comments.go
+++ b/internal/validators/file/ai_comments.go
@@ -19,7 +19,7 @@ import (
 var defaultAICommentPatterns = []string{
 	// A comment opening (optionally after "the"/"a") with a verb whose only
 	// job is to describe the mechanics of the following statement.
-	`(?i)(//|#)\s*(the\s+|a\s+|an\s+)?` +
+	`(?i)(^\s*|\s)(//|#)\s*(the\s+|a\s+|an\s+)?` +
 		`(initiali[sz]|set|reset|get|loop|iterate|check|return|` +
 		`creat|mak|build|construct|instantiat|` +
 		`call|invok|execut|run|increment|decrement|` +
@@ -36,7 +36,7 @@ var defaultAICommentPatterns = []string{
 		`toggl|enabl|disabl|mark|lock|bind|connect)` +
 		`(e|es|ed|d|s|ing|ping|ting|ning|ling|ging|ies|ied|y)?\b`,
 	// "This function/method/... does/is/handles/..." restatements.
-	`(?i)(//|#)\s*this\s+(function|method|class|struct|interface|type|` +
+	`(?i)(^\s*|\s)(//|#)\s*this\s+(function|method|class|struct|interface|type|` +
 		`variable|field|constant|value|helper|wrapper)\s+` +
 		`(does|is|are|will|handles?|returns?|sets?|gets?|` +
 		`represents?|holds?|stores?|contains?)\b`,
@@ -64,8 +64,10 @@ var aiExportedDecl = regexp.MustCompile(
 		`)`,
 )
 
-// aiCommentMarker locates the start of a // or # comment on a line.
-var aiCommentMarker = regexp.MustCompile(`(//|#)`)
+// aiCommentMarker locates the start of a // or # comment on a line. It anchors
+// to line start or whitespace so markers inside string/URL literals (e.g. the
+// "//" in "https://…") are not treated as comments.
+var aiCommentMarker = regexp.MustCompile(`(^\s*|\s)(//|#)`)
 
 // AICommentValidator flags filler comments that only restate adjacent code,
 // a pattern common in LLM-generated output.

--- a/internal/validators/file/ai_comments_broaden_test.go
+++ b/internal/validators/file/ai_comments_broaden_test.go
@@ -71,4 +71,18 @@ var _ = Describe("AICommentValidator broadened coverage", func() {
 		Entry("blank line breaks doc association",
 			"// Returns the user.\n\nfunc GetUser() {\n}"),
 	)
+	DescribeTable(
+		"allows // or # inside string and URL literals",
+		func(content string) {
+			ctx.ToolInput.Content = content
+			result := v.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeTrue())
+		},
+		Entry("https url with verb after slashes",
+			`endpoint := "https://set.example.com/v1"`),
+		Entry("http url with verb",
+			`u := "http://config.example.com/handle"`),
+		Entry("hash inside string literal",
+			`color := "#set0aa"`),
+	)
 })

--- a/internal/validators/file/ai_comments_broaden_test.go
+++ b/internal/validators/file/ai_comments_broaden_test.go
@@ -1,0 +1,74 @@
+package file_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/smykla-skalski/klaudiush/internal/validators/file"
+	"github.com/smykla-skalski/klaudiush/pkg/hook"
+	"github.com/smykla-skalski/klaudiush/pkg/logger"
+)
+
+var _ = Describe("AICommentValidator broadened coverage", func() {
+	var (
+		v   *file.AICommentValidator
+		ctx *hook.Context
+	)
+
+	BeforeEach(func() {
+		v = file.NewAICommentValidator(logger.NewNoOpLogger(), nil, nil)
+		ctx = &hook.Context{
+			EventType: hook.EventTypePreToolUse,
+			ToolName:  hook.ToolTypeWrite,
+		}
+	})
+
+	DescribeTable(
+		"flags comments that open with a restating verb",
+		func(content string) {
+			ctx.ToolInput.Content = content
+			result := v.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeFalse())
+		},
+		Entry("configure", "// Configure the http client\ncli := newClient()"),
+		Entry("handle", "// Handle the incoming request\nserve(r)"),
+		Entry("parse", "// Parse the json payload\np := parse(b)"),
+		Entry("increment without article", "// Increment counter\ncounter++"),
+		Entry("append", "// Append the item\nlist = append(list, x)"),
+		Entry("validate", "// Validate the input\ncheckInput(in)"),
+		Entry("iterate", "// Iterate over rows\nfor range rows {\n}"),
+		Entry("send", "// Send the response\nwrite(b)"),
+	)
+
+	DescribeTable(
+		"allows comments that are not filler",
+		func(content string) {
+			ctx.ToolInput.Content = content
+			result := v.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeTrue())
+		},
+		Entry("TODO marker", "// TODO: return the cached value\nreturn nil"),
+		Entry("FIXME marker", "// FIXME handle the retry path\nx := 1"),
+		Entry("exported Go func doc",
+			"// Returns the user for the given id.\nfunc GetUser(id string) *User { return nil }"),
+		Entry("exported JS function",
+			"// Creates a new widget instance.\nexport function makeWidget() {}"),
+		Entry("why comment",
+			"// Guard against nil to avoid a shutdown panic.\nif cli == nil {\n}"),
+	)
+
+	DescribeTable(
+		"still flags filler that is not a doc comment",
+		func(content string) {
+			ctx.ToolInput.Content = content
+			result := v.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeFalse())
+		},
+		Entry("unexported func",
+			"// Returns the user for the given id.\nfunc getUser(id string) *User { return nil }"),
+		Entry("blank line breaks doc association",
+			"// Returns the user.\n\nfunc GetUser() {\n}"),
+	)
+})


### PR DESCRIPTION
## Motivation

The `ai_comments` validator (FILE011) only matched about ten fixed
throat-clearing phrases, so most real filler comments slipped through
(`// configure the client`, `// handle the request`, `// parse the
payload`, `// increment counter`, ...). The goal is to block filler
comments broadly while keeping legitimate comments — task markers and
documentation on public APIs — untouched.

## Implementation information

- Detection now flags any comment that opens (behind `//` or `#`,
  optionally after `the`/`a`/`an`) with a code-restating verb, covering
  ~70 common verbs instead of a fixed phrase list.
- Two carve-outs keep false positives down:
  - Task/annotation markers: `TODO`, `FIXME`, `HACK`, `XXX`, `BUG`,
    `WARNING`, `@annotations`.
  - Doc-comment blocks directly above an exported/public declaration
    (Go exported func/type/const/var, JS/TS `export`, Python
    `def`/`class`); a blank line breaks the exemption.
- Key property: idiomatic Go docs open with the identifier name and
  "why" comments open with a reason, so neither trips the check — only
  verb-first narration of what the next line does.
- Added table-driven tests and updated `docs/errors/FILE011.md`.

Build, vet, lint, and the file-validator test suite pass.

## Supporting documentation

`docs/errors/FILE011.md`