### PR TITLE
feat(validator): block inline comments by default

### DIFF
--- a/docs/errors/FILE011.md
+++ b/docs/errors/FILE011.md
@@ -1,66 +1,73 @@
-# FILE011: Filler comment detected
+# FILE011: Inline comment not allowed
 
 ## Error
 
-Code being written or edited contains a comment that opens with an action
-verb narrating *what* the next line does (e.g., `// Initialize the counter`,
-`// Loop through items`, `// Return the result`, `// Configure the client`).
+Code being written or edited to a **source file** contains an in-body comment
+that is not an allowed form (see below). By default klaudiush runs in **strict**
+mode: every comment inside source code is blocked unless it is a task marker, a
+machine directive, a doc comment on an exported declaration, or carries an
+exception token.
 
 ## Why this matters
 
-Filler comments restate *what* the code does instead of *why* it does it.
-Well-named identifiers already communicate the "what"; a comment repeating it
-adds noise and rots the moment the code changes underneath it. This pattern is
-common in LLM-generated code. Idiomatic doc comments (which open with the
-identifier name) and "why" comments (which open with a reason) are unaffected.
+LLM-generated code tends to narrate itself — restating *what* a line does, or
+padding a one-line decision with several lines of rationalization. Well-named
+identifiers already communicate the "what", and load-bearing "why" explanations
+are rare. Blocking inline comments by default pushes toward self-explanatory
+code and keeps the few genuinely-needed explanations explicit and reviewable.
 
 ## How to fix
 
-Remove the comment, or replace it with one that explains a non-obvious
-reason:
+Remove the comment and let the code speak, or rename identifiers so the intent
+is obvious:
 
 ```go
 // Instead of:
-// Initialize the counter
-count := 0
+count := 0 // holds the running total
 
-// Fix: remove it, or explain the why
-count := 0 // starts at zero to match the 1-indexed API offset
+// Fix: name it well and drop the comment
+runningTotal := 0
 ```
 
-## Detected patterns
+If a comment is genuinely load-bearing (documents a non-obvious invariant),
+append an exception token so it is allowed:
 
-A comment is flagged when it opens (behind `//` or `#`, optionally after
-`the`/`a`/`an`) with a code-restating verb: initialize, set, get, loop,
-iterate, check, return, create, make, build, call, invoke, execute, run,
-increment/decrement, add/append/insert/push, remove/delete/clear/pop,
-update/modify/change, handle, process, parse/format/convert, encode/decode,
-marshal/unmarshal, compute/calculate, assign/declare/define, configure,
-register, open/close/read/write, load/save/store, fetch/send/receive,
-wait/start/stop, print/log/emit, render/draw, filter/sort/find/search/count,
-validate/verify/ensure, and similar. Also caught: "This function/method/...
-does/is/handles/...".
+```go
+if err != nil {
+    return true // EXC:FILE011:unreadable-store-assumes-a-tracker-exists
+}
+```
 
 ## Allowed (not flagged)
 
-- Task and annotation markers: `// TODO: ...`, `// FIXME ...`, `// HACK`,
-  `// XXX`, `// BUG`, `// OPTIMIZE`, `// REVIEW`, `// DEPRECATED`, `@annotations`.
-- Doc comments directly above an exported/public declaration (Go exported
-  func/type/const/var, JS/TS `export`, Python `def`/`class`) — a blank line
-  between the comment and the declaration breaks this exemption.
-- Any comment that does not open with a restating verb (e.g. a "why" comment).
+- **Task and annotation markers**: `TODO`, `FIXME`, `HACK`, `XXX`, `BUG`, `WARNING`, `NOTE`, `OPTIMIZE`, `REVIEW`, `DEPRECATED`, and `@annotations`.
+- **Doc comments** directly above an exported/public declaration (Go exported func/type/const/var, JS/TS `export`, Python public `def`/`class`). A blank line between the comment and the declaration breaks this exemption; comments on **unexported** declarations are not exempt.
+- **Machine directives**: shebangs, Go compiler directives (build constraints, code generation), cgo directives, legacy build tags, character-encoding cookies, and the type/lint/coverage suppression comments recognised by language tooling.
+- **Exception tokens**: any comment containing `EXC:<CODE>:<reason>`.
+- **All comments in non-source files**: config, markup, data and shell files (`.toml`, `.yaml`, `.json`, `.md`, `.ini`, `.env`, `.sh`, `Makefile`, `Dockerfile`, ...) use the lenient pattern-based behaviour instead.
+
+## Modes
+
+- **strict** (default): blocks all in-body comments in source files except the allowed forms above.
+- **filler**: blocks only comments matching a filler pattern — a verb-first restatement (initialize, loop, return, configure, handle, parse, encode, ...) or a "This function/method/... does/is/handles/..." restatement. Legitimate "why" comments are allowed. This is the pre-1.36 behaviour and is also used for non-source files regardless of mode.
 
 ## Configuration
-
-Enable it and optionally override the pattern list:
 
 ```toml
 [validators.file.ai_comments]
 enabled = true
-patterns = []   # custom patterns (overrides defaults when set)
+mode = "strict"   # "strict" (default) or "filler"
+patterns = []     # custom filler-mode patterns (overrides defaults when set)
 ```
 
-Disable the validator:
+Restore the old lenient behaviour:
+
+```toml
+[validators.file.ai_comments]
+mode = "filler"
+```
+
+Disable the validator entirely:
 
 ```toml
 [validators.file.ai_comments]
@@ -72,7 +79,7 @@ enabled = false
 When this error is triggered, klaudiush writes JSON to stdout:
 
 **permissionDecisionReason** (shown to Claude):
-`[FILE011] Filler comments that only restate the code are not allowed. Remove the comment or replace it with one that explains why, not what`
+`[FILE011] Inline comments are not allowed — write self-explanatory code instead. ...`
 
 **systemMessage** (shown to user):
 Formatted error with fix hint and reference URL.

--- a/internal/validators/file/ai_comments.go
+++ b/internal/validators/file/ai_comments.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"context"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -46,9 +47,55 @@ var defaultAICommentPatterns = []string{
 // These carry intent ("what still needs doing") rather than restating code and
 // are always allowed.
 var aiTodoMarker = regexp.MustCompile(
-	`(?i)^\s*(TODO|FIXME|HACK|XXX|BUG|WARNING|` +
+	`(?i)^\s*(TODO|FIXME|HACK|XXX|BUG|WARNING|NOTE|` +
 		`OPTIMI[SZ]E|REVIEW|DEPRECATED)\b|^\s*@\w+`,
 )
+
+// aiDirectiveMarker matches machine-readable directives and interpreter hints
+// that must never be treated as prose: shebangs, build constraints, codegen and
+// linter pragmas, and character-encoding cookies. These are load-bearing
+// (flagging them would break compilation or tooling), so they are always
+// allowed regardless of policy. Matched against the comment body with leading
+// whitespace trimmed.
+var aiDirectiveMarker = regexp.MustCompile(
+	`(?i)^(` +
+		`[!/]` + // shebang (#!), Rust doc (///), Rust inner doc (//!)
+		`|go:` + // Go compiler directives
+		`|line\b|export\b` + // cgo //line, //export
+		`|\+build\b` + // legacy build tags
+		`|nolint\b` + // linter pragma
+		`|-\*-|coding[:=]` + // character-encoding cookie
+		`|type:|noqa\b|pragma\b` + // Python type/coverage pragmas
+		`|(py(lint|right)|mypy|flake8|ruff|isort|fmt):` +
+		`|shellcheck\b|swiftlint:` +
+		`|eslint-|@ts-|prettier-ignore|biome-ignore|oxlint-|istanbul\b|c8\b|@flow\b` +
+		`)`,
+)
+
+// aiExceptionToken matches an inline EXC:<CODE>:<reason> escape token, letting a
+// genuinely load-bearing comment opt out of the block. Mirrors the exception
+// token format used elsewhere (see internal/exceptions).
+var aiExceptionToken = regexp.MustCompile(`(?:^|\s)EXC:[A-Z]{2,10}[0-9]{1,5}:\S`)
+
+// nonStrictExtensions are file types whose comments are ordinarily
+// human-authored documentation (config, markup, data, shell) rather than inline
+// code narration. For these the validator keeps pattern-based behaviour instead
+// of the strict block-all policy.
+var nonStrictExtensions = map[string]bool{
+	".toml": true, ".yaml": true, ".yml": true, ".json": true, ".jsonc": true,
+	".json5": true, ".md": true, ".markdown": true, ".mdx": true, ".txt": true,
+	".rst": true, ".ini": true, ".cfg": true, ".conf": true, ".config": true,
+	".env": true, ".properties": true, ".lock": true, ".csv": true, ".tsv": true,
+	".xml": true, ".html": true, ".htm": true, ".svg": true, ".sql": true,
+	".mk": true, ".sh": true, ".bash": true, ".zsh": true, ".fish": true,
+	".ksh": true, ".ps1": true,
+}
+
+// nonStrictBasenames are extension-less files whose comments are documentation.
+var nonStrictBasenames = map[string]bool{
+	"makefile": true, "gnumakefile": true, "dockerfile": true,
+	".gitignore": true, ".dockerignore": true, ".gitattributes": true,
+}
 
 // aiExportedDecl matches a source line that declares an exported/public symbol.
 // A leading comment block directly above such a line is its documentation and
@@ -64,13 +111,53 @@ var aiExportedDecl = regexp.MustCompile(
 		`)`,
 )
 
-// aiCommentMarker locates the start of a // or # comment on a line. It anchors
-// to line start or whitespace so markers inside string/URL literals (e.g. the
-// "//" in "https://…") are not treated as comments.
-var aiCommentMarker = regexp.MustCompile(`(^\s*|\s)(//|#)`)
+// findCommentStart returns the byte index of the first line-comment marker
+// (// or #) that is a real code-level comment, or -1 if the line has none. It
+// tracks single/double/backtick string state so a marker inside a string or URL
+// literal (e.g. the "//" in "https://…" or a " //" inside "a // b") is ignored,
+// and requires the marker to sit at line start or after whitespace.
+func findCommentStart(line string) int {
+	var inSingle, inDouble, inBack bool
 
-// AICommentValidator flags filler comments that only restate adjacent code,
-// a pattern common in LLM-generated output.
+	for i := 0; i < len(line); i++ {
+		c := line[i]
+
+		switch {
+		case (inSingle || inDouble) && c == '\\':
+			i++ // skip the escaped character
+		case c == '\'' && !inDouble && !inBack:
+			inSingle = !inSingle
+		case c == '"' && !inSingle && !inBack:
+			inDouble = !inDouble
+		case c == '`' && !inSingle && !inDouble:
+			inBack = !inBack
+		case inSingle || inDouble || inBack:
+			// inside a string literal: markers here are not comments
+		case c == '#' && (i == 0 || line[i-1] == ' ' || line[i-1] == '\t'):
+			return i
+		case c == '/' && i+1 < len(line) && line[i+1] == '/' &&
+			(i == 0 || line[i-1] == ' ' || line[i-1] == '\t'):
+			return i
+		}
+	}
+
+	return -1
+}
+
+// commentBody returns the comment text after the marker at idx (the "//" or "#"
+// characters stripped), preserving any leading whitespace.
+func commentBody(line string, idx int) string {
+	if line[idx] == '#' {
+		return line[idx+1:]
+	}
+
+	return line[idx+2:]
+}
+
+// AICommentValidator flags in-body comments. In strict mode (default) it blocks
+// every comment in a source file except task markers, machine directives, doc
+// comments on exported declarations, and comments carrying an EXC: token. In
+// filler mode it blocks only comments matching the configured patterns.
 type AICommentValidator struct {
 	validator.BaseValidator
 	config   *config.AICommentValidatorConfig
@@ -96,8 +183,15 @@ func NewAICommentValidator(
 // aiCommentHeader is the message header shown when a filler comment is blocked.
 const aiCommentHeader = "Filler comments that only restate the code are not allowed"
 
-// Validate checks for filler comments that restate adjacent code, allowing
-// task markers and doc comments on exported declarations.
+// aiCommentStrictHeader is shown when strict mode blocks an in-body comment.
+const aiCommentStrictHeader = "Inline comments are not allowed — write self-explanatory code instead.\n" +
+	"Allowed: TODO/FIXME/NOTE markers, doc comments on exported declarations,\n" +
+	"and machine directives. To keep a load-bearing comment, append an\n" +
+	"exception token, e.g. // EXC:FILE011:documents-a-non-obvious-invariant."
+
+// Validate blocks in-body comments per the configured mode, exempting task
+// markers, machine directives, doc comments on exported declarations, and
+// comments carrying an EXC: token.
 func (v *AICommentValidator) Validate(
 	ctx context.Context,
 	hookCtx *hook.Context,
@@ -111,35 +205,73 @@ func (v *AICommentValidator) Validate(
 		return validator.Pass()
 	}
 
-	violations := findAICommentViolations(content, v.patterns)
+	strict := v.strictForPath(hookCtx.GetFilePath())
+
+	violations := findAICommentViolations(content, v.patterns, strict)
 	if len(violations) == 0 {
 		return validator.Pass()
 	}
 
+	header := aiCommentHeader
+	if strict {
+		header = aiCommentStrictHeader
+	}
+
 	return validator.FailWithRef(
 		validator.RefAIComments,
-		formatPatternViolations(aiCommentHeader, violations),
+		formatPatternViolations(header, violations),
 	)
 }
 
-// findAICommentViolations reports filler comments while exempting task markers
-// and documentation on exported declarations.
-func findAICommentViolations(content string, patterns []*regexp.Regexp) []violation {
+// strictForPath reports whether the strict block-all policy applies to the given
+// file. Filler mode disables it, and config/markup/data/shell files always use
+// pattern-based behaviour so their ordinary documentation comments are allowed.
+func (v *AICommentValidator) strictForPath(path string) bool {
+	if v.config != nil && v.config.Mode == config.AICommentModeFiller {
+		return false
+	}
+
+	base := strings.ToLower(filepath.Base(path))
+	if nonStrictBasenames[base] {
+		return false
+	}
+
+	return !nonStrictExtensions[strings.ToLower(filepath.Ext(path))]
+}
+
+// findAICommentViolations reports blocked comments. Task markers, machine
+// directives, exception tokens, and doc comments on exported declarations are
+// always exempt. In strict mode every other comment is a violation; in filler
+// mode only comments matching a pattern are.
+func findAICommentViolations(content string, patterns []*regexp.Regexp, strict bool) []violation {
 	var violations []violation
 
 	lines := strings.Split(content, "\n")
 
 	for i, line := range lines {
-		loc := aiCommentMarker.FindStringIndex(line)
-		if loc == nil {
+		idx := findCommentStart(line)
+		if idx < 0 {
 			continue
 		}
 
-		if aiTodoMarker.MatchString(line[loc[1]:]) {
+		body := commentBody(line, idx)
+
+		if aiTodoMarker.MatchString(body) ||
+			aiDirectiveMarker.MatchString(strings.TrimLeft(body, " \t")) ||
+			aiExceptionToken.MatchString(body) {
 			continue
 		}
 
 		if isFullLineComment(line) && precedesExportedDecl(lines, i) {
+			continue
+		}
+
+		if strict {
+			violations = append(violations, violation{
+				line:      i + 1,
+				directive: strings.TrimSpace(line[idx:]),
+			})
+
 			continue
 		}
 

--- a/internal/validators/file/ai_comments.go
+++ b/internal/validators/file/ai_comments.go
@@ -59,8 +59,7 @@ var aiTodoMarker = regexp.MustCompile(
 // whitespace trimmed.
 var aiDirectiveMarker = regexp.MustCompile(
 	`(?i)^(` +
-		`[!/]` + // shebang (#!), Rust doc (///), Rust inner doc (//!)
-		`|go:` + // Go compiler directives
+		`go:` + // Go compiler directives
 		`|line\b|export\b` + // cgo //line, //export
 		`|\+build\b` + // legacy build tags
 		`|nolint\b` + // linter pragma
@@ -115,9 +114,12 @@ var aiExportedDecl = regexp.MustCompile(
 // (// or #) that is a real code-level comment, or -1 if the line has none. It
 // tracks single/double/backtick string state so a marker inside a string or URL
 // literal (e.g. the "//" in "https://…" or a " //" inside "a // b") is ignored,
-// and requires the marker to sit at line start or after whitespace.
-func findCommentStart(line string) int {
-	var inSingle, inDouble, inBack bool
+// and requires the marker to sit at line start or after whitespace. inBack is
+// the backtick-string state carried in from the previous line (Go raw strings
+// and JS template literals span lines); the updated state is returned so the
+// caller can thread it. Single/double quotes are treated as line-local.
+func findCommentStart(line string, inBack bool) (idx int, endInBack bool) {
+	var inSingle, inDouble bool
 
 	for i := 0; i < len(line); i++ {
 		c := line[i]
@@ -125,23 +127,31 @@ func findCommentStart(line string) int {
 		switch {
 		case (inSingle || inDouble) && c == '\\':
 			i++ // skip the escaped character
+		case c == '`' && !inSingle && !inDouble:
+			inBack = !inBack
 		case c == '\'' && !inDouble && !inBack:
 			inSingle = !inSingle
 		case c == '"' && !inSingle && !inBack:
 			inDouble = !inDouble
-		case c == '`' && !inSingle && !inDouble:
-			inBack = !inBack
 		case inSingle || inDouble || inBack:
 			// inside a string literal: markers here are not comments
 		case c == '#' && (i == 0 || line[i-1] == ' ' || line[i-1] == '\t'):
-			return i
+			return i, inBack
 		case c == '/' && i+1 < len(line) && line[i+1] == '/' &&
 			(i == 0 || line[i-1] == ' ' || line[i-1] == '\t'):
-			return i
+			return i, inBack
 		}
 	}
 
-	return -1
+	return -1, inBack
+}
+
+// isShebangOrDocMarker reports whether the comment body (marker stripped, not
+// trimmed) is a shebang (#!), a Rust doc comment (///) or a Rust inner doc
+// comment (//!). These sit flush against the marker, so a leading space (an
+// ordinary comment like "// /tmp/foo") is intentionally not matched.
+func isShebangOrDocMarker(body string) bool {
+	return len(body) > 0 && (body[0] == '/' || body[0] == '!')
 }
 
 // commentBody returns the comment text after the marker at idx (the "//" or "#"
@@ -236,7 +246,14 @@ func (v *AICommentValidator) strictForPath(path string) bool {
 		return false
 	}
 
-	return !nonStrictExtensions[strings.ToLower(filepath.Ext(path))]
+	// filepath.Ext(".env") is "" — treat a leading-dot name with no other dot
+	// as its own extension so dotfiles like .env classify correctly.
+	ext := strings.ToLower(filepath.Ext(base))
+	if ext == "" && strings.HasPrefix(base, ".") {
+		ext = base
+	}
+
+	return !nonStrictExtensions[ext]
 }
 
 // findAICommentViolations reports blocked comments. Task markers, machine
@@ -248,8 +265,12 @@ func findAICommentViolations(content string, patterns []*regexp.Regexp, strict b
 
 	lines := strings.Split(content, "\n")
 
+	var inBack bool
+
 	for i, line := range lines {
-		idx := findCommentStart(line)
+		var idx int
+
+		idx, inBack = findCommentStart(line, inBack)
 		if idx < 0 {
 			continue
 		}
@@ -257,6 +278,7 @@ func findAICommentViolations(content string, patterns []*regexp.Regexp, strict b
 		body := commentBody(line, idx)
 
 		if aiTodoMarker.MatchString(body) ||
+			isShebangOrDocMarker(body) ||
 			aiDirectiveMarker.MatchString(strings.TrimLeft(body, " \t")) ||
 			aiExceptionToken.MatchString(body) {
 			continue

--- a/internal/validators/file/ai_comments_broaden_test.go
+++ b/internal/validators/file/ai_comments_broaden_test.go
@@ -80,7 +80,36 @@ var _ = Describe("AICommentValidator broadened coverage", func() {
 		Entry("trailing narration", "x := compute()  // holds the running total"),
 		Entry("doc comment on unexported func",
 			"// helper does the thing.\nfunc helper() {}"),
+		Entry("prose starting with a slash is not a Rust doc",
+			"x := 1\n// /tmp is where we stash it for now"),
 	)
+
+	DescribeTable(
+		"does not mistake markers inside multi-line backtick strings for comments",
+		func(content string) {
+			ctx.ToolInput.Content = content
+			result := v.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeTrue())
+		},
+		Entry("go raw string spanning lines with // inside",
+			"q := `SELECT 1\nFROM t -- note\nWHERE u // not a comment`\nreturn q"),
+		Entry("go raw string with # inside",
+			"tmpl := `line one\n# not a comment here\nline three`\nreturn tmpl"),
+	)
+
+	It("allows Rust doc comments (///)", func() {
+		ctx.ToolInput.FilePath = "/repo/lib.rs"
+		ctx.ToolInput.Content = "/// Widget models a thing.\npub struct Widget;"
+		result := v.Validate(context.Background(), ctx)
+		Expect(result.Passed).To(BeTrue())
+	})
+
+	It("keeps .env dotfiles on pattern-based behaviour", func() {
+		ctx.ToolInput.FilePath = "/repo/.env"
+		ctx.ToolInput.Content = "# API host for the beta cohort\nHOST=localhost"
+		result := v.Validate(context.Background(), ctx)
+		Expect(result.Passed).To(BeTrue())
+	})
 
 	DescribeTable(
 		"still flags filler that is not a doc comment",

--- a/internal/validators/file/ai_comments_broaden_test.go
+++ b/internal/validators/file/ai_comments_broaden_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/smykla-skalski/klaudiush/internal/validators/file"
+	"github.com/smykla-skalski/klaudiush/pkg/config"
 	"github.com/smykla-skalski/klaudiush/pkg/hook"
 	"github.com/smykla-skalski/klaudiush/pkg/logger"
 )
@@ -43,7 +44,7 @@ var _ = Describe("AICommentValidator broadened coverage", func() {
 	)
 
 	DescribeTable(
-		"allows comments that are not filler",
+		"allows markers, directives and doc comments",
 		func(content string) {
 			ctx.ToolInput.Content = content
 			result := v.Validate(context.Background(), ctx)
@@ -51,12 +52,34 @@ var _ = Describe("AICommentValidator broadened coverage", func() {
 		},
 		Entry("TODO marker", "// TODO: return the cached value\nreturn nil"),
 		Entry("FIXME marker", "// FIXME handle the retry path\nx := 1"),
+		Entry("NOTE marker", "// NOTE: keep in sync with the proto\nx := 1"),
 		Entry("exported Go func doc",
 			"// Returns the user for the given id.\nfunc GetUser(id string) *User { return nil }"),
 		Entry("exported JS function",
 			"// Creates a new widget instance.\nexport function makeWidget() {}"),
-		Entry("why comment",
-			"// Guard against nil to avoid a shutdown panic.\nif cli == nil {\n}"),
+		Entry("go:generate directive", "//go:generate mockgen -source=x.go\nx := 1"),
+		Entry("go:build constraint", "//go:build linux\npackage foo"),
+		Entry("exception token escape hatch",
+			"// EXC:FILE011:documents-a-load-bearing-invariant here\nreturn true"),
+	)
+
+	DescribeTable(
+		"strict mode blocks in-body prose that no pattern would catch",
+		func(content string) {
+			ctx.ToolInput.Content = content
+			result := v.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeFalse())
+		},
+		Entry("why comment", "// Guard against nil to avoid a shutdown panic.\nif cli == nil {\n}"),
+		Entry("multi-line rationalization",
+			"return false\n"+
+				"// Unreadable store: assume a tracker exists. Claiming this stub as\n"+
+				"// the only record would mint a second task for the same issue — the\n"+
+				"// exact duplication this helper prevents; a mislabeled stub is cheaper.\n"+
+				"s.logger.Error(\"scan\")"),
+		Entry("trailing narration", "x := compute()  // holds the running total"),
+		Entry("doc comment on unexported func",
+			"// helper does the thing.\nfunc helper() {}"),
 	)
 
 	DescribeTable(
@@ -84,5 +107,46 @@ var _ = Describe("AICommentValidator broadened coverage", func() {
 			`u := "http://config.example.com/handle"`),
 		Entry("hash inside string literal",
 			`color := "#set0aa"`),
+		Entry("double-slash inside string literal",
+			`msg := "before // after"`),
 	)
+
+	DescribeTable(
+		"config/markup/data/shell files keep pattern-based behaviour",
+		func(path string) {
+			ctx.ToolInput.FilePath = path
+			ctx.ToolInput.Content = "# Feature flag for the beta cohort\nfoo = true"
+			result := v.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeTrue())
+		},
+		Entry("toml config", "/repo/config.toml"),
+		Entry("yaml config", "/repo/values.yaml"),
+		Entry("shell script", "/repo/setup.sh"),
+		Entry("Makefile", "/repo/Makefile"),
+	)
+
+	It("strict mode blocks in-body comments in a .go file", func() {
+		ctx.ToolInput.FilePath = "/repo/svc.go"
+		ctx.ToolInput.Content = "x := f()\n// holds the running total"
+		result := v.Validate(context.Background(), ctx)
+		Expect(result.Passed).To(BeFalse())
+	})
+
+	It("filler mode opt-out allows a plain why comment", func() {
+		fv := file.NewAICommentValidator(
+			logger.NewNoOpLogger(),
+			&config.AICommentValidatorConfig{Mode: config.AICommentModeFiller},
+			nil,
+		)
+		fctx := &hook.Context{
+			EventType: hook.EventTypePreToolUse,
+			ToolName:  hook.ToolTypeWrite,
+			ToolInput: hook.ToolInput{
+				FilePath: "/repo/svc.go",
+				Content:  "// Guard against nil to avoid a panic.\nif c == nil {\n}",
+			},
+		}
+		result := fv.Validate(context.Background(), fctx)
+		Expect(result.Passed).To(BeTrue())
+	})
 })

--- a/internal/validators/file/ai_comments_test.go
+++ b/internal/validators/file/ai_comments_test.go
@@ -125,7 +125,7 @@ count := 0
 				Expect(result.ShouldBlock).To(BeTrue())
 				Expect(
 					result.Message,
-				).To(ContainSubstring("Filler comments that only restate the code are not allowed"))
+				).To(ContainSubstring("Inline comments are not allowed"))
 			})
 
 			It("fails for 'Loop through'", func() {

--- a/pkg/config/file.go
+++ b/pkg/config/file.go
@@ -344,11 +344,32 @@ type LinterIgnoreValidatorConfig struct {
 	Patterns []string `json:"patterns,omitempty" koanf:"patterns" toml:"patterns,omitempty"`
 }
 
-// AICommentValidatorConfig configures the AI filler comment validator.
+// AI comment validator modes.
+const (
+	// AICommentModeStrict blocks every in-body comment in source files,
+	// allowing only task markers, machine directives, doc comments on
+	// exported declarations, and comments carrying an EXC: exception token.
+	// This is the default.
+	AICommentModeStrict = "strict"
+
+	// AICommentModeFiller keeps the lenient pattern-based behaviour: only
+	// comments matching a filler pattern (verb-first restatement, etc.) are
+	// blocked.
+	AICommentModeFiller = "filler"
+)
+
+// AICommentValidatorConfig configures the AI comment validator.
 type AICommentValidatorConfig struct {
 	ValidatorConfig `koanf:",squash"`
 
-	// Patterns is a list of regex patterns to detect filler comments.
-	// Default: built-in patterns for throat-clearing phrases (initialize, loop through, etc.)
+	// Mode selects the detection policy: "strict" (default) blocks all
+	// in-body comments in source files except allowed forms; "filler" only
+	// blocks comments matching Patterns. Config, markup, data and shell files
+	// always use pattern-based behaviour regardless of Mode.
+	Mode string `json:"mode,omitempty" koanf:"mode" toml:"mode,omitempty"`
+
+	// Patterns is a list of regex patterns to detect filler comments in
+	// "filler" mode (and in non-source files). Default: built-in patterns for
+	// verb-first restatements (initialize, loop through, etc.)
 	Patterns []string `json:"patterns,omitempty" koanf:"patterns" toml:"patterns,omitempty"`
 }

--- a/pkg/config/file.go
+++ b/pkg/config/file.go
@@ -366,7 +366,7 @@ type AICommentValidatorConfig struct {
 	// in-body comments in source files except allowed forms; "filler" only
 	// blocks comments matching Patterns. Config, markup, data and shell files
 	// always use pattern-based behaviour regardless of Mode.
-	Mode string `json:"mode,omitempty" koanf:"mode" toml:"mode,omitempty"`
+	Mode string `json:"mode,omitempty" jsonschema:"enum=strict,enum=filler" koanf:"mode" toml:"mode,omitempty"`
 
 	// Patterns is a list of regex patterns to detect filler comments in
 	// "filler" mode (and in non-source files). Default: built-in patterns for

--- a/schema/config.v1.schema.json
+++ b/schema/config.v1.schema.json
@@ -13,6 +13,13 @@
         "rules_enabled": {
           "type": "boolean"
         },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "strict",
+            "filler"
+          ]
+        },
         "patterns": {
           "items": {
             "type": "string"
@@ -337,6 +344,45 @@
         "5m"
       ]
     },
+    "ElicitationConfig": {
+      "properties": {
+        "server": {
+          "$ref": "#/$defs/ElicitationServerConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ElicitationServerConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "severity": {
+          "$ref": "#/$defs/Severity"
+        },
+        "rules_enabled": {
+          "type": "boolean"
+        },
+        "allowed_servers": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "denied_servers": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "block_url_mode": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "ExceptionAuditConfig": {
       "properties": {
         "enabled": {
@@ -482,6 +528,18 @@
         },
         "ai_comments": {
           "$ref": "#/$defs/AICommentValidatorConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "GeminiProviderConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "settings_path": {
+          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -923,6 +981,9 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "block_ai_attribution": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,
@@ -1074,6 +1135,9 @@
         },
         "codex": {
           "$ref": "#/$defs/CodexProviderConfig"
+        },
+        "gemini": {
+          "$ref": "#/$defs/GeminiProviderConfig"
         }
       },
       "additionalProperties": false,
@@ -1097,6 +1161,12 @@
           "type": "array"
         },
         "allowed_remote_priority": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "blocked_branches": {
           "items": {
             "type": "string"
           },
@@ -1198,7 +1268,8 @@
           "type": "string",
           "enum": [
             "claude",
-            "codex"
+            "codex",
+            "gemini"
           ]
         },
         "repo_pattern": {
@@ -1276,12 +1347,17 @@
             "session_start",
             "turn_stop",
             "notification",
+            "pre_compress",
             "PreToolUse",
             "PostToolUse",
             "Notification",
             "SessionStart",
             "Stop",
-            "AfterToolUse"
+            "AfterToolUse",
+            "BeforeTool",
+            "AfterTool",
+            "SessionEnd",
+            "PreCompress"
           ]
         },
         "case_insensitive": {
@@ -1513,6 +1589,21 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "UpdateCheckConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "check_interval": {
+          "$ref": "#/$defs/Duration"
+        },
+        "notify": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "ValidatorsConfig": {
       "properties": {
         "git": {
@@ -1532,6 +1623,9 @@
         },
         "shell": {
           "$ref": "#/$defs/ShellConfig"
+        },
+        "elicitation": {
+          "$ref": "#/$defs/ElicitationConfig"
         }
       },
       "additionalProperties": false,
@@ -1607,6 +1701,9 @@
     },
     "overrides": {
       "$ref": "#/$defs/OverridesConfig"
+    },
+    "update_check": {
+      "$ref": "#/$defs/UpdateCheckConfig"
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
## Motivation

The AI comment validator was allow-by-default: it only flagged verb-first
restatements (`// Configure the client`) and `// This function does X`.
Multi-line "why" rambles — the dominant AI-slop tell — matched no pattern and
slipped through. Example that passed before this change:

```go
if err != nil {
    return false
    // Unreadable store: assume a tracker exists. Claiming this stub as the
    // only record would mint a second TaskTypeUmbrella task for the same
    // issue — the exact duplication this helper prevents; a mislabeled
    // duplicate stub is the cheaper failure.
    s.logger.Error("scan")
    return true
}
```

## Implementation information

Inverted the policy to **strict block-all** (`internal/validators/file/ai_comments.go`):

- In source files, every in-body comment is blocked unless it is:
  - a task marker (`TODO/FIXME/HACK/XXX/BUG/WARNING/NOTE/…`, `@annotations`)
  - a machine directive (shebangs, `//go:*`, cgo, build tags, linter/encoding/type pragmas)
  - a doc comment directly above an **exported** declaration
  - a comment carrying an inline `EXC:<CODE>:<reason>` escape token
- Added a quote-aware comment finder so ` //`/`#` inside string/URL literals are not treated as comments (needed once block-all removed the pattern masking).
- Scoped strict mode to source files; config/markup/data/shell (`.toml`, `.yaml`, `.md`, `.sh`, `Makefile`, ...) keep the pattern-based behaviour.
- Added `mode = "filler"` config to restore the previous lenient behaviour.
- Rewrote `docs/errors/FILE011.md`; updated and extended tests (strict blocks, escape hatch, file-type scoping, filler opt-out).

> Changelog: feat(validator): block inline comments by default

**Behavioral note:** strict becomes the default for all users on upgrade. Set `mode = "filler"` to keep the old behaviour.

## Supporting documentation

- `docs/errors/FILE011.md`