### PR TITLE
chore(deps): group Go version bumps

### DIFF
--- a/.github/sync-config.yml
+++ b/.github/sync-config.yml
@@ -26,6 +26,14 @@ sync:
           extends:
             - "customManagers:githubActionsVersions"
           packageRules:
+            - description: "Group Go version updates from gomod and mise into a single PR"
+              groupName: "go version"
+              matchDepNames:
+                - go
+              matchManagers:
+                - gomod
+                - mise
+              rangeStrategy: bump
             - description: "Group Charm Go modules"
               groupName: "Charm modules"
               matchManagers:

--- a/renovate.json
+++ b/renovate.json
@@ -50,16 +50,11 @@
       "groupName": "{{{replace 'https://github\\.com/[a-z-]+/' '' sourceUrl}}}"
     },
     {
-      "description": "Enable Go version updates in go.mod",
-      "matchManagers": ["gomod"],
+      "description": "Group Go version updates from gomod and mise into a single PR",
+      "groupName": "go version",
       "matchDepNames": ["go"],
+      "matchManagers": ["gomod", "mise"],
       "rangeStrategy": "bump"
-    },
-    {
-      "description": "Group Go version updates across mise and go.mod",
-      "groupName": "Go",
-      "matchPackageNames": ["go"],
-      "matchDatasources": ["golang-version"]
     },
     {
       "description": "Group Charm Go modules",


### PR DESCRIPTION
## Summary

Group Renovate Go version updates from the `gomod` and `mise` managers into one PR, matching the Kuma configuration shape without forcing `enabled: true`.

Keep `.github/sync-config.yml` in sync so org config sync preserves the repo-specific Go grouping rule.

## Validation

- `mise run lint`
- `mise run test`
- pre-push hook: `lint`, `test`, `test-testscript`