### PR TITLE
fix(file): relax FILE011 comment policy

### DIFF
--- a/docs/errors/FILE011.md
+++ b/docs/errors/FILE011.md
@@ -1,20 +1,19 @@
-# FILE011: Inline comment not allowed
+# FILE011: Filler comment not allowed
 
 ## Error
 
-Code being written or edited to a **source file** contains an in-body comment
-that is not an allowed form (see below). By default klaudiush runs in **strict**
-mode: every comment inside source code is blocked unless it is a task marker, a
-machine directive, a doc comment on an exported declaration, or carries an
-exception token.
+Code being written or edited contains a comment that looks like filler: prose
+that only restates what the adjacent code already says.
+
+If `mode = "strict"` is configured for source files, klaudiush also blocks
+in-body comments unless they are an allowed form: a task marker, machine
+directive, doc comment on a declaration, test phase marker, or exception token.
 
 ## Why this matters
 
-LLM-generated code tends to narrate itself — restating *what* a line does, or
-padding a one-line decision with several lines of rationalization. Well-named
-identifiers already communicate the "what", and load-bearing "why" explanations
-are rare. Blocking inline comments by default pushes toward self-explanatory
-code and keeps the few genuinely-needed explanations explicit and reviewable.
+LLM-generated code tends to narrate itself by restating *what* a line does.
+Well-named identifiers already communicate the "what"; comments should carry
+intent, invariants, protocol notes, or test structure.
 
 ## How to fix
 
@@ -29,8 +28,8 @@ count := 0 // holds the running total
 runningTotal := 0
 ```
 
-If a comment is genuinely load-bearing (documents a non-obvious invariant),
-append an exception token so it is allowed:
+In strict mode, if a non-doc in-body comment is genuinely load-bearing
+(documents a non-obvious invariant), append an exception token so it is allowed:
 
 ```go
 if err != nil {
@@ -41,30 +40,31 @@ if err != nil {
 ## Allowed (not flagged)
 
 - **Task and annotation markers**: `TODO`, `FIXME`, `HACK`, `XXX`, `BUG`, `WARNING`, `NOTE`, `OPTIMIZE`, `REVIEW`, `DEPRECATED`, and `@annotations`.
-- **Doc comments** directly above an exported/public declaration (Go exported func/type/const/var, JS/TS `export`, Python public `def`/`class`). A blank line between the comment and the declaration breaks this exemption; comments on **unexported** declarations are not exempt.
+- **Doc comments** directly above a declaration (Go package/func/type/const/var, JS/TS `export`, Python `def`/`class`). A blank line between the comment and the declaration breaks this exemption.
+- **BDD/test phase markers** in Go test files (`*_test.go`): `given`, `when`, `then`, `arrange`, `act`, and `assert`.
 - **Machine directives**: shebangs, Go compiler directives (build constraints, code generation), cgo directives, legacy build tags, character-encoding cookies, and the type/lint/coverage suppression comments recognised by language tooling.
 - **Exception tokens**: any comment containing `EXC:<CODE>:<reason>`.
 - **All comments in non-source files**: config, markup, data and shell files (`.toml`, `.yaml`, `.json`, `.md`, `.ini`, `.env`, `.sh`, `Makefile`, `Dockerfile`, ...) use the lenient pattern-based behaviour instead.
 
 ## Modes
 
-- **strict** (default): blocks all in-body comments in source files except the allowed forms above.
-- **filler**: blocks only comments matching a filler pattern — a verb-first restatement (initialize, loop, return, configure, handle, parse, encode, ...) or a "This function/method/... does/is/handles/..." restatement. Legitimate "why" comments are allowed. This is the pre-1.36 behaviour and is also used for non-source files regardless of mode.
+- **filler** (default): blocks only comments matching a filler pattern — a verb-first restatement (initialize, loop, return, configure, handle, parse, encode, ...) or a "This function/method/... does/is/handles/..." restatement. Legitimate "why" comments are allowed.
+- **strict**: blocks all in-body comments in source files except the allowed forms above. Non-source files still use filler behavior.
 
 ## Configuration
 
 ```toml
 [validators.file.ai_comments]
 enabled = true
-mode = "strict"   # "strict" (default) or "filler"
+mode = "filler"   # "filler" (default) or "strict"
 patterns = []     # custom filler-mode patterns (overrides defaults when set)
 ```
 
-Restore the old lenient behaviour:
+Enable strict block-all behavior for source files:
 
 ```toml
 [validators.file.ai_comments]
-mode = "filler"
+mode = "strict"
 ```
 
 Disable the validator entirely:
@@ -79,7 +79,7 @@ enabled = false
 When this error is triggered, klaudiush writes JSON to stdout:
 
 **permissionDecisionReason** (shown to Claude):
-`[FILE011] Inline comments are not allowed — write self-explanatory code instead. ...`
+`[FILE011] Filler comments that only restate the code are not allowed. ...`
 
 **systemMessage** (shown to user):
 Formatted error with fix hint and reference URL.

--- a/docs/errors/FILE011.md
+++ b/docs/errors/FILE011.md
@@ -79,7 +79,14 @@ enabled = false
 When this error is triggered, klaudiush writes JSON to stdout:
 
 **permissionDecisionReason** (shown to Claude):
+
+Default filler mode:
+
 `[FILE011] Filler comments that only restate the code are not allowed. ...`
+
+Strict mode:
+
+`[FILE011] Inline comments are not allowed — write self-explanatory code instead. ...`
 
 **systemMessage** (shown to user):
 Formatted error with fix hint and reference URL.

--- a/docs/errors/FILE011.md
+++ b/docs/errors/FILE011.md
@@ -41,7 +41,7 @@ if err != nil {
 
 - **Task and annotation markers**: `TODO`, `FIXME`, `HACK`, `XXX`, `BUG`, `WARNING`, `NOTE`, `OPTIMIZE`, `REVIEW`, `DEPRECATED`, and `@annotations`.
 - **Doc comments** directly above a declaration (Go package/func/type/const/var, JS/TS `export`, Python `def`/`class`). A blank line between the comment and the declaration breaks this exemption. Generic restatements such as `This function does ...` are still filler comments and can be flagged.
-- **BDD/test phase markers** in Go test files (`*_test.go`): `given`, `when`, `then`, `arrange`, `act`, and `assert`.
+- **Standalone BDD/test phase markers** in Go test files (`*_test.go`): full-line `given`, `when`, `then`, `arrange`, `act`, and `assert` comments.
 - **Machine directives**: shebangs, Go compiler directives (build constraints, code generation), cgo directives, legacy build tags, character-encoding cookies, and the type/lint/coverage suppression comments recognised by language tooling.
 - **Exception tokens**: any comment containing `EXC:<CODE>:<reason>`.
 - **All comments in non-source files**: config, markup, data and shell files (`.toml`, `.yaml`, `.json`, `.md`, `.ini`, `.env`, `.sh`, `Makefile`, `Dockerfile`, ...) use the lenient pattern-based behaviour instead.

--- a/docs/errors/FILE011.md
+++ b/docs/errors/FILE011.md
@@ -40,7 +40,7 @@ if err != nil {
 ## Allowed (not flagged)
 
 - **Task and annotation markers**: `TODO`, `FIXME`, `HACK`, `XXX`, `BUG`, `WARNING`, `NOTE`, `OPTIMIZE`, `REVIEW`, `DEPRECATED`, and `@annotations`.
-- **Doc comments** directly above a declaration (Go package/func/type/const/var, JS/TS `export`, Python `def`/`class`). A blank line between the comment and the declaration breaks this exemption.
+- **Doc comments** directly above a declaration (Go package/func/type/const/var, JS/TS `export`, Python `def`/`class`). A blank line between the comment and the declaration breaks this exemption. Generic restatements such as `This function does ...` are still filler comments and can be flagged.
 - **BDD/test phase markers** in Go test files (`*_test.go`): `given`, `when`, `then`, `arrange`, `act`, and `assert`.
 - **Machine directives**: shebangs, Go compiler directives (build constraints, code generation), cgo directives, legacy build tags, character-encoding cookies, and the type/lint/coverage suppression comments recognised by language tooling.
 - **Exception tokens**: any comment containing `EXC:<CODE>:<reason>`.

--- a/internal/validators/file/ai_comments.go
+++ b/internal/validators/file/ai_comments.go
@@ -38,16 +38,16 @@ var defaultAICommentPatterns = []string{
 		`(e|es|ed|d|s|ing|ping|ting|ning|ling|ging|ies|ied|y)?\b`,
 	// "This function/method/... does/is/handles/..." restatements.
 	`(?i)(^\s*|\s)(//|#)\s*this\s+(function|method|class|struct|interface|type|` +
-		`variable|field|constant|value|helper|wrapper)\s+` +
+		`variable|field|constant|value|helper|wrapper|package)\s+` +
 		`(does|is|are|will|handles?|returns?|sets?|gets?|` +
-		`represents?|holds?|stores?|contains?)\b`,
+		`represents?|holds?|stores?|contains?|provides?)\b`,
 }
 
 // aiGenericDocComment matches doc comments that avoid the declaration name and
 // instead narrate the declaration kind. These are still filler comments.
 var aiGenericDocComment = regexp.MustCompile(
 	`(?i)^\s*this\s+(function|method|class|struct|interface|type|` +
-		`variable|field|constant|value|helper|wrapper)\b`,
+		`variable|field|constant|value|helper|wrapper|package)\b`,
 )
 
 // aiTodoMarker matches a comment that opens with a task or annotation marker.
@@ -208,7 +208,7 @@ const aiCommentHeader = "Filler comments that only restate the code are not allo
 
 // aiCommentStrictHeader is shown when strict mode blocks an in-body comment.
 const aiCommentStrictHeader = "Inline comments are not allowed — write self-explanatory code instead.\n" +
-	"Allowed: TODO/FIXME/NOTE markers, non-generic declaration doc comments,\n" +
+	"Allowed: task/annotation markers, non-generic declaration doc comments,\n" +
 	"standalone Go *_test.go phase markers, and machine directives. To keep a\n" +
 	"comment, append an exception token, e.g.\n" +
 	"// EXC:FILE011:documents-a-non-obvious-invariant."

--- a/internal/validators/file/ai_comments.go
+++ b/internal/validators/file/ai_comments.go
@@ -43,12 +43,25 @@ var defaultAICommentPatterns = []string{
 		`represents?|holds?|stores?|contains?)\b`,
 }
 
+// aiGenericDocComment matches doc comments that avoid the declaration name and
+// instead narrate the declaration kind. These are still filler comments.
+var aiGenericDocComment = regexp.MustCompile(
+	`(?i)^\s*this\s+(function|method|class|struct|interface|type|` +
+		`variable|field|constant|value|helper|wrapper)\b`,
+)
+
 // aiTodoMarker matches a comment that opens with a task or annotation marker.
 // These carry intent ("what still needs doing") rather than restating code and
 // are always allowed.
 var aiTodoMarker = regexp.MustCompile(
 	`(?i)^\s*(TODO|FIXME|HACK|XXX|BUG|WARNING|NOTE|` +
 		`OPTIMI[SZ]E|REVIEW|DEPRECATED)\b|^\s*@\w+`,
+)
+
+// aiTestPhaseMarker matches BDD-style phase markers commonly used in tests.
+// They structure test intent rather than narrating implementation details.
+var aiTestPhaseMarker = regexp.MustCompile(
+	`(?i)^\s*(given|when|then|arrange|act|assert)\b`,
 )
 
 // aiDirectiveMarker matches machine-readable directives and interpreter hints
@@ -96,15 +109,15 @@ var nonStrictBasenames = map[string]bool{
 	".gitignore": true, ".dockerignore": true, ".gitattributes": true,
 }
 
-// aiExportedDecl matches a source line that declares an exported/public symbol.
+// aiDocDecl matches a source line that declares a symbol or package.
 // A leading comment block directly above such a line is its documentation and
-// is allowed even when it opens with a verb (Go requires doc comments on
-// exported identifiers).
-var aiExportedDecl = regexp.MustCompile(
+// is allowed even when it opens with a verb.
+var aiDocDecl = regexp.MustCompile(
 	`^\s*(` +
-		`func\s+(\([^)]*\)\s*)?[A-Z]` + // Go exported func or method
-		`|type\s+[A-Z]` + // Go exported type
-		`|(const|var)\s+[A-Z]` + // Go exported const/var
+		`package\s+[A-Za-z_]` + // Go package doc
+		`|func\s+(\([^)]*\)\s*)?[A-Za-z_]` + // Go func or method
+		`|type\s+[A-Za-z_]` + // Go type
+		`|(const|var)\s+(\(|[A-Za-z_])` + // Go const/var or block
 		`|export\b` + // JS/TS export
 		`|(async\s+)?(def|class)\s+[A-Za-z]` + // Python def/class (public: no leading _)
 		`)`,
@@ -164,10 +177,10 @@ func commentBody(line string, idx int) string {
 	return line[idx+2:]
 }
 
-// AICommentValidator flags in-body comments. In strict mode (default) it blocks
-// every comment in a source file except task markers, machine directives, doc
-// comments on exported declarations, and comments carrying an EXC: token. In
-// filler mode it blocks only comments matching the configured patterns.
+// AICommentValidator flags in-body comments. In strict mode it blocks every
+// comment in a source file except task markers, machine directives, doc
+// comments, test phase markers, and comments carrying an EXC: token. In filler
+// mode it blocks only comments matching the configured patterns.
 type AICommentValidator struct {
 	validator.BaseValidator
 	config   *config.AICommentValidatorConfig
@@ -195,13 +208,14 @@ const aiCommentHeader = "Filler comments that only restate the code are not allo
 
 // aiCommentStrictHeader is shown when strict mode blocks an in-body comment.
 const aiCommentStrictHeader = "Inline comments are not allowed — write self-explanatory code instead.\n" +
-	"Allowed: TODO/FIXME/NOTE markers, doc comments on exported declarations,\n" +
-	"and machine directives. To keep a load-bearing comment, append an\n" +
-	"exception token, e.g. // EXC:FILE011:documents-a-non-obvious-invariant."
+	"Allowed: TODO/FIXME/NOTE markers, doc comments on declarations,\n" +
+	"test phase markers, and machine directives. To keep a load-bearing\n" +
+	"comment, append an exception token, e.g.\n" +
+	"// EXC:FILE011:documents-a-non-obvious-invariant."
 
 // Validate blocks in-body comments per the configured mode, exempting task
-// markers, machine directives, doc comments on exported declarations, and
-// comments carrying an EXC: token.
+// markers, machine directives, doc comments, test phase markers, and comments
+// carrying an EXC: token.
 func (v *AICommentValidator) Validate(
 	ctx context.Context,
 	hookCtx *hook.Context,
@@ -215,9 +229,11 @@ func (v *AICommentValidator) Validate(
 		return validator.Pass()
 	}
 
-	strict := v.strictForPath(hookCtx.GetFilePath())
+	path := hookCtx.GetFilePath()
+	strict := v.strictForPath(path)
+	allowTestPhaseMarkers := allowsTestPhaseMarkers(path)
 
-	violations := findAICommentViolations(content, v.patterns, strict)
+	violations := findAICommentViolations(content, v.patterns, strict, allowTestPhaseMarkers)
 	if len(violations) == 0 {
 		return validator.Pass()
 	}
@@ -237,7 +253,7 @@ func (v *AICommentValidator) Validate(
 // file. Filler mode disables it, and config/markup/data/shell files always use
 // pattern-based behaviour so their ordinary documentation comments are allowed.
 func (v *AICommentValidator) strictForPath(path string) bool {
-	if v.config != nil && v.config.Mode == config.AICommentModeFiller {
+	if v.config == nil || v.config.Mode != config.AICommentModeStrict {
 		return false
 	}
 
@@ -256,11 +272,24 @@ func (v *AICommentValidator) strictForPath(path string) bool {
 	return !nonStrictExtensions[ext]
 }
 
+// allowsTestPhaseMarkers reports whether BDD-style test phase comments should
+// be exempted for the given file.
+func allowsTestPhaseMarkers(path string) bool {
+	base := strings.ToLower(filepath.Base(path))
+
+	return strings.HasSuffix(base, "_test.go")
+}
+
 // findAICommentViolations reports blocked comments. Task markers, machine
-// directives, exception tokens, and doc comments on exported declarations are
-// always exempt. In strict mode every other comment is a violation; in filler
-// mode only comments matching a pattern are.
-func findAICommentViolations(content string, patterns []*regexp.Regexp, strict bool) []violation {
+// directives, exception tokens, doc comments, and configured test phase markers
+// are always exempt. In strict mode every other comment is a violation; in
+// filler mode only comments matching a pattern are.
+func findAICommentViolations(
+	content string,
+	patterns []*regexp.Regexp,
+	strict bool,
+	allowTestPhaseMarkers bool,
+) []violation {
 	var violations []violation
 
 	lines := strings.Split(content, "\n")
@@ -284,7 +313,12 @@ func findAICommentViolations(content string, patterns []*regexp.Regexp, strict b
 			continue
 		}
 
-		if isFullLineComment(line) && precedesExportedDecl(lines, i) {
+		if allowTestPhaseMarkers && aiTestPhaseMarker.MatchString(body) {
+			continue
+		}
+
+		if isFullLineComment(line) && precedesDocDecl(lines, i) &&
+			!aiGenericDocComment.MatchString(body) {
 			continue
 		}
 
@@ -321,10 +355,10 @@ func isFullLineComment(line string) bool {
 	return strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "#")
 }
 
-// precedesExportedDecl reports whether the comment at index i is part of a
-// leading comment block whose first non-comment line declares an exported
-// symbol. A blank line breaks the association (it is no longer a doc comment).
-func precedesExportedDecl(lines []string, i int) bool {
+// precedesDocDecl reports whether the comment at index i is part of a leading
+// comment block whose first non-comment line declares a symbol or package. A
+// blank line breaks the association (it is no longer a doc comment).
+func precedesDocDecl(lines []string, i int) bool {
 	for j := i + 1; j < len(lines); j++ {
 		trimmed := strings.TrimSpace(lines[j])
 		if trimmed == "" {
@@ -335,7 +369,7 @@ func precedesExportedDecl(lines []string, i int) bool {
 			continue
 		}
 
-		return aiExportedDecl.MatchString(lines[j])
+		return aiDocDecl.MatchString(lines[j])
 	}
 
 	return false

--- a/internal/validators/file/ai_comments.go
+++ b/internal/validators/file/ai_comments.go
@@ -179,7 +179,7 @@ func commentBody(line string, idx int) string {
 
 // AICommentValidator flags in-body comments. In strict mode it blocks every
 // comment in a source file except task markers, machine directives, doc
-// comments, test phase markers, and comments carrying an EXC: token. In filler
+// comments, Go test phase markers, and comments carrying an EXC: token. In filler
 // mode it blocks only comments matching the configured patterns.
 type AICommentValidator struct {
 	validator.BaseValidator
@@ -209,12 +209,12 @@ const aiCommentHeader = "Filler comments that only restate the code are not allo
 // aiCommentStrictHeader is shown when strict mode blocks an in-body comment.
 const aiCommentStrictHeader = "Inline comments are not allowed — write self-explanatory code instead.\n" +
 	"Allowed: TODO/FIXME/NOTE markers, doc comments on declarations,\n" +
-	"test phase markers, and machine directives. To keep a load-bearing\n" +
+	"Go *_test.go phase markers, and machine directives. To keep a load-bearing\n" +
 	"comment, append an exception token, e.g.\n" +
 	"// EXC:FILE011:documents-a-non-obvious-invariant."
 
 // Validate blocks in-body comments per the configured mode, exempting task
-// markers, machine directives, doc comments, test phase markers, and comments
+// markers, machine directives, doc comments, Go test phase markers, and comments
 // carrying an EXC: token.
 func (v *AICommentValidator) Validate(
 	ctx context.Context,

--- a/internal/validators/file/ai_comments.go
+++ b/internal/validators/file/ai_comments.go
@@ -208,8 +208,8 @@ const aiCommentHeader = "Filler comments that only restate the code are not allo
 
 // aiCommentStrictHeader is shown when strict mode blocks an in-body comment.
 const aiCommentStrictHeader = "Inline comments are not allowed — write self-explanatory code instead.\n" +
-	"Allowed: TODO/FIXME/NOTE markers, doc comments on declarations,\n" +
-	"Go *_test.go phase markers, and machine directives. To keep a load-bearing\n" +
+	"Allowed: TODO/FIXME/NOTE markers, non-generic declaration doc comments,\n" +
+	"standalone Go *_test.go phase markers, and machine directives. To keep a\n" +
 	"comment, append an exception token, e.g.\n" +
 	"// EXC:FILE011:documents-a-non-obvious-invariant."
 

--- a/internal/validators/file/ai_comments.go
+++ b/internal/validators/file/ai_comments.go
@@ -313,7 +313,8 @@ func findAICommentViolations(
 			continue
 		}
 
-		if allowTestPhaseMarkers && aiTestPhaseMarker.MatchString(body) {
+		if allowTestPhaseMarkers && isFullLineComment(line) &&
+			aiTestPhaseMarker.MatchString(body) {
 			continue
 		}
 

--- a/internal/validators/file/ai_comments.go
+++ b/internal/validators/file/ai_comments.go
@@ -281,7 +281,7 @@ func allowsTestPhaseMarkers(path string) bool {
 }
 
 // findAICommentViolations reports blocked comments. Task markers, machine
-// directives, exception tokens, doc comments, and configured test phase markers
+// directives, exception tokens, doc comments, and Go test phase markers
 // are always exempt. In strict mode every other comment is a violation; in
 // filler mode only comments matching a pattern are.
 func findAICommentViolations(

--- a/internal/validators/file/ai_comments.go
+++ b/internal/validators/file/ai_comments.go
@@ -116,7 +116,7 @@ var aiDocDecl = regexp.MustCompile(
 	`^\s*(` +
 		`package\s+[A-Za-z_]` + // Go package doc
 		`|func\s+(\([^)]*\)\s*)?[A-Za-z_]` + // Go func or method
-		`|type\s+[A-Za-z_]` + // Go type
+		`|type\s+(\(|[A-Za-z_])` + // Go type or block
 		`|(const|var)\s+(\(|[A-Za-z_])` + // Go const/var or block
 		`|export\b` + // JS/TS export
 		`|(async\s+)?(def|class)\s+[A-Za-z_]` + // Python def/class

--- a/internal/validators/file/ai_comments.go
+++ b/internal/validators/file/ai_comments.go
@@ -119,7 +119,7 @@ var aiDocDecl = regexp.MustCompile(
 		`|type\s+[A-Za-z_]` + // Go type
 		`|(const|var)\s+(\(|[A-Za-z_])` + // Go const/var or block
 		`|export\b` + // JS/TS export
-		`|(async\s+)?(def|class)\s+[A-Za-z]` + // Python def/class (public: no leading _)
+		`|(async\s+)?(def|class)\s+[A-Za-z_]` + // Python def/class
 		`)`,
 )
 

--- a/internal/validators/file/ai_comments_broaden_test.go
+++ b/internal/validators/file/ai_comments_broaden_test.go
@@ -62,6 +62,8 @@ var _ = Describe("AICommentValidator broadened coverage", func() {
 				"func (s *statsCallbacks) maybeReportWindowDepletion(last lastSend) {}"),
 		Entry("Go package doc",
 			"// Package dispatcher validates hook events.\npackage dispatcher"),
+		Entry("Go type block doc",
+			"// Returns known validation states.\ntype (\n\tvalidationState string\n)"),
 		Entry("private Python def doc",
 			"# Returns the configured value.\ndef _get_value():\n    return value"),
 		Entry("exported JS function",

--- a/internal/validators/file/ai_comments_broaden_test.go
+++ b/internal/validators/file/ai_comments_broaden_test.go
@@ -62,6 +62,8 @@ var _ = Describe("AICommentValidator broadened coverage", func() {
 				"func (s *statsCallbacks) maybeReportWindowDepletion(last lastSend) {}"),
 		Entry("Go package doc",
 			"// Package dispatcher validates hook events.\npackage dispatcher"),
+		Entry("private Python def doc",
+			"# Returns the configured value.\ndef _get_value():\n    return value"),
 		Entry("exported JS function",
 			"// Creates a new widget instance.\nexport function makeWidget() {}"),
 		Entry("go:generate directive", "//go:generate mockgen -source=x.go\nx := 1"),

--- a/internal/validators/file/ai_comments_broaden_test.go
+++ b/internal/validators/file/ai_comments_broaden_test.go
@@ -55,6 +55,13 @@ var _ = Describe("AICommentValidator broadened coverage", func() {
 		Entry("NOTE marker", "// NOTE: keep in sync with the proto\nx := 1"),
 		Entry("exported Go func doc",
 			"// Returns the user for the given id.\nfunc GetUser(id string) *User { return nil }"),
+		Entry("unexported Go func doc",
+			"// maybeReportWindowDepletion emits the warning log and increments the\n"+
+				"// counter when the most recent send on a now-closed stream matches the\n"+
+				"// receive-window-depletion signature.\n"+
+				"func (s *statsCallbacks) maybeReportWindowDepletion(last lastSend) {}"),
+		Entry("Go package doc",
+			"// Package dispatcher validates hook events.\npackage dispatcher"),
 		Entry("exported JS function",
 			"// Creates a new widget instance.\nexport function makeWidget() {}"),
 		Entry("go:generate directive", "//go:generate mockgen -source=x.go\nx := 1"),
@@ -64,11 +71,11 @@ var _ = Describe("AICommentValidator broadened coverage", func() {
 	)
 
 	DescribeTable(
-		"strict mode blocks in-body prose that no pattern would catch",
+		"default mode allows why-comments that no filler pattern catches",
 		func(content string) {
 			ctx.ToolInput.Content = content
 			result := v.Validate(context.Background(), ctx)
-			Expect(result.Passed).To(BeFalse())
+			Expect(result.Passed).To(BeTrue())
 		},
 		Entry("why comment", "// Guard against nil to avoid a shutdown panic.\nif cli == nil {\n}"),
 		Entry("multi-line rationalization",
@@ -77,9 +84,28 @@ var _ = Describe("AICommentValidator broadened coverage", func() {
 				"// the only record would mint a second task for the same issue — the\n"+
 				"// exact duplication this helper prevents; a mislabeled stub is cheaper.\n"+
 				"s.logger.Error(\"scan\")"),
+		Entry("preview build explanation",
+			"// Preview builds report version 0.0.0-preview.* which sorts below every\n"+
+				"// released version; treat them as latest rather than legacy.\n"+
+				"latest := embeddedDNS"),
+		Entry("prose starting with a slash is not a Rust doc",
+			"x := 1\n// /tmp is where we stash it for now"),
+	)
+
+	DescribeTable(
+		"explicit strict mode blocks in-body prose that no pattern catches",
+		func(content string) {
+			sv := file.NewAICommentValidator(
+				logger.NewNoOpLogger(),
+				&config.AICommentValidatorConfig{Mode: config.AICommentModeStrict},
+				nil,
+			)
+			ctx.ToolInput.Content = content
+			result := sv.Validate(context.Background(), ctx)
+			Expect(result.Passed).To(BeFalse())
+		},
+		Entry("why comment", "// Guard against nil to avoid a shutdown panic.\nif cli == nil {\n}"),
 		Entry("trailing narration", "x := compute()  // holds the running total"),
-		Entry("doc comment on unexported func",
-			"// helper does the thing.\nfunc helper() {}"),
 		Entry("prose starting with a slash is not a Rust doc",
 			"x := 1\n// /tmp is where we stash it for now"),
 	)
@@ -118,8 +144,10 @@ var _ = Describe("AICommentValidator broadened coverage", func() {
 			result := v.Validate(context.Background(), ctx)
 			Expect(result.Passed).To(BeFalse())
 		},
-		Entry("unexported func",
-			"// Returns the user for the given id.\nfunc getUser(id string) *User { return nil }"),
+		Entry(
+			"in-body return narration",
+			"if id == \"\" {\n\treturn nil\n}\n// Returns the user for the given id.\nreturn getUser(id)",
+		),
 		Entry("blank line breaks doc association",
 			"// Returns the user.\n\nfunc GetUser() {\n}"),
 	)
@@ -154,10 +182,22 @@ var _ = Describe("AICommentValidator broadened coverage", func() {
 		Entry("Makefile", "/repo/Makefile"),
 	)
 
-	It("strict mode blocks in-body comments in a .go file", func() {
+	It("allows BDD phase markers in Go tests", func() {
+		ctx.ToolInput.FilePath = "/repo/svc_test.go"
+		ctx.ToolInput.Content = "func TestFlow(t *testing.T) {\n// given a cached response\nseed()\n// when loading data\nload()\n// then status is fresh\nassertFresh()\n}"
+		result := v.Validate(context.Background(), ctx)
+		Expect(result.Passed).To(BeTrue())
+	})
+
+	It("explicit strict mode blocks in-body comments in a .go file", func() {
+		sv := file.NewAICommentValidator(
+			logger.NewNoOpLogger(),
+			&config.AICommentValidatorConfig{Mode: config.AICommentModeStrict},
+			nil,
+		)
 		ctx.ToolInput.FilePath = "/repo/svc.go"
 		ctx.ToolInput.Content = "x := f()\n// holds the running total"
-		result := v.Validate(context.Background(), ctx)
+		result := sv.Validate(context.Background(), ctx)
 		Expect(result.Passed).To(BeFalse())
 	})
 

--- a/internal/validators/file/ai_comments_broaden_test.go
+++ b/internal/validators/file/ai_comments_broaden_test.go
@@ -154,6 +154,8 @@ var _ = Describe("AICommentValidator broadened coverage", func() {
 		),
 		Entry("blank line breaks doc association",
 			"// Returns the user.\n\nfunc GetUser() {\n}"),
+		Entry("generic package doc",
+			"// This package provides validation helpers.\npackage dispatcher"),
 	)
 	DescribeTable(
 		"allows // or # inside string and URL literals",

--- a/internal/validators/file/ai_comments_broaden_test.go
+++ b/internal/validators/file/ai_comments_broaden_test.go
@@ -191,6 +191,18 @@ var _ = Describe("AICommentValidator broadened coverage", func() {
 		Expect(result.Passed).To(BeTrue())
 	})
 
+	It("does not allow BDD phase markers as trailing comments in strict mode", func() {
+		sv := file.NewAICommentValidator(
+			logger.NewNoOpLogger(),
+			&config.AICommentValidatorConfig{Mode: config.AICommentModeStrict},
+			nil,
+		)
+		ctx.ToolInput.FilePath = "/repo/svc_test.go"
+		ctx.ToolInput.Content = "seed() // given a cached response"
+		result := sv.Validate(context.Background(), ctx)
+		Expect(result.Passed).To(BeFalse())
+	})
+
 	It("explicit strict mode blocks in-body comments in a .go file", func() {
 		sv := file.NewAICommentValidator(
 			logger.NewNoOpLogger(),

--- a/internal/validators/file/ai_comments_test.go
+++ b/internal/validators/file/ai_comments_test.go
@@ -125,7 +125,7 @@ count := 0
 				Expect(result.ShouldBlock).To(BeTrue())
 				Expect(
 					result.Message,
-				).To(ContainSubstring("Inline comments are not allowed"))
+				).To(ContainSubstring("Filler comments that only restate the code are not allowed"))
 			})
 
 			It("fails for 'Loop through'", func() {

--- a/pkg/config/file.go
+++ b/pkg/config/file.go
@@ -347,8 +347,8 @@ type LinterIgnoreValidatorConfig struct {
 // AI comment validator modes.
 const (
 	// AICommentModeStrict blocks every in-body comment in source files,
-	// allowing only task markers, machine directives, doc comments, test phase
-	// markers, and comments carrying an EXC: exception token.
+	// allowing only task markers, machine directives, doc comments, Go test
+	// phase markers, and comments carrying an EXC: exception token.
 	AICommentModeStrict = "strict"
 
 	// AICommentModeFiller keeps the default pattern-based behaviour: only

--- a/pkg/config/file.go
+++ b/pkg/config/file.go
@@ -347,12 +347,11 @@ type LinterIgnoreValidatorConfig struct {
 // AI comment validator modes.
 const (
 	// AICommentModeStrict blocks every in-body comment in source files,
-	// allowing only task markers, machine directives, doc comments on
-	// exported declarations, and comments carrying an EXC: exception token.
-	// This is the default.
+	// allowing only task markers, machine directives, doc comments, test phase
+	// markers, and comments carrying an EXC: exception token.
 	AICommentModeStrict = "strict"
 
-	// AICommentModeFiller keeps the lenient pattern-based behaviour: only
+	// AICommentModeFiller keeps the default pattern-based behaviour: only
 	// comments matching a filler pattern (verb-first restatement, etc.) are
 	// blocked.
 	AICommentModeFiller = "filler"
@@ -362,8 +361,8 @@ const (
 type AICommentValidatorConfig struct {
 	ValidatorConfig `koanf:",squash"`
 
-	// Mode selects the detection policy: "strict" (default) blocks all
-	// in-body comments in source files except allowed forms; "filler" only
+	// Mode selects the detection policy: "strict" blocks all in-body comments
+	// in source files except allowed forms; "filler" (default when unset) only
 	// blocks comments matching Patterns. Config, markup, data and shell files
 	// always use pattern-based behaviour regardless of Mode.
 	Mode string `json:"mode,omitempty" jsonschema:"enum=strict,enum=filler" koanf:"mode" toml:"mode,omitempty"`


### PR DESCRIPTION
## Summary

Fixes #546.

- Switch FILE011 default behavior back to filler-pattern detection unless strict mode is explicitly configured.
- Allow Go doc comments on package, exported, and unexported declarations.
- Allow BDD-style test phase markers in `*_test.go` files.
- Keep explicit strict mode and generic filler-comment blocking available.

## Validation

- `mise run fmt`
- `mise run test:unit`
- `mise run check`
- `GO_TEST_P=1 mise run test:unit` on the rebased branch
- pre-push hook with `GO_TEST_P=1`: lint, test, test-testscript