### PR TITLE
ci(deps): bump actions/create-github-app-token to v3.2.0

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: generate-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.SMYKLOT_APP_ID }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/nix-vendor-hash.yml
+++ b/.github/workflows/nix-vendor-hash.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.SMYKLOT_APP_ID }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.SMYKLOT_APP_ID }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
@@ -111,7 +111,7 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.SMYKLOT_APP_ID }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
@@ -167,7 +167,7 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.SMYKLOT_APP_ID }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/smyklot-poll.yml
+++ b/.github/workflows/smyklot-poll.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   poll-reactions:
     name: Poll PR Reactions
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.RUNNER_LABEL || '["ubuntu-24.04"]') }}
 
     steps:
       - name: Checkout repository
@@ -29,13 +29,13 @@ jobs:
 
       - name: Generate GitHub App token
         id: generate-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.SMYKLOT_APP_ID }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
 
       - name: Poll reactions on open PRs
-        uses: smykla-skalski/smyklot@2059852fc4166dc6353887db42e13276506d7215 # v1.11.2
+        uses: smykla-skalski/smyklot@e8e0c9f8b02f5e507df95af7a0b1635bc81df478 # v1.12.0
         with:
           args: poll
         env:

--- a/.github/workflows/smyklot-pr-commands.yml
+++ b/.github/workflows/smyklot-pr-commands.yml
@@ -20,12 +20,12 @@ jobs:
   handle-command:
     name: Handle PR Command
     if: github.event.issue.pull_request && github.event.comment.user.type != 'Bot'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(vars.RUNNER_LABEL || '["ubuntu-24.04"]') }}
 
     steps:
       - name: Generate GitHub App token
         id: generate-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.SMYKLOT_APP_ID }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Smyklot
-        uses: smykla-skalski/smyklot@2059852fc4166dc6353887db42e13276506d7215 # v1.11.2
+        uses: smykla-skalski/smyklot@e8e0c9f8b02f5e507df95af7a0b1635bc81df478 # v1.12.0
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           COMMENT_BODY: ${{ github.event.comment.body }}

--- a/.github/workflows/sync-trigger.yml
+++ b/.github/workflows/sync-trigger.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Generate App Token
         id: token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.SMYKLOT_APP_ID }}
           private-key: ${{ secrets.SMYKLOT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Submodule checkout in klaudiu.sh was pinned at an old commit still using
actions/create-github-app-token v2.2.1, well behind main. Rather than
advance the submodule pointer (187 commits / 231 files of unrelated drift),
this pulls just the token-action fix, sourced from the real upstream
commits (2be045fa and 14a9f5e) rather than hand-edited.

## Changes

- claude.yml, nix-vendor-hash.yml, release.yml, sync-trigger.yml:
  create-github-app-token v2.2.1 -> v3.2.0
- smyklot-poll.yml, smyklot-pr-commands.yml: same token bump, plus the
  smyklot action v1.11.2 -> v1.12.0 bump and runs-on RUNNER_LABEL fix that
  shipped together with it in 14a9f5e