### PR TITLE
ci(actions): pin changelog preset to 9.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,10 +86,18 @@ jobs:
         id: semantic
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
         with:
+          # conventional-changelog-conventionalcommits is pinned to 9.x on
+          # purpose. From 10.0.0 the preset switched to
+          # @conventional-changelog/template and requires
+          # conventional-changelog-writer 9 or newer, while
+          # @semantic-release/release-notes-generator@14 still depends on
+          # writer 8. Leaving it unpinned resolves to the newest major at
+          # install time, which aborts the release with "Missing helper".
+          # Drop the constraint once release-notes-generator ships writer 9.
           extra_plugins: |
             @semantic-release/changelog
             @semantic-release/exec
-            conventional-changelog-conventionalcommits
+            conventional-changelog-conventionalcommits@^9.3.1
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GIT_AUTHOR_NAME: smyklot[bot]


### PR DESCRIPTION
## Motivation

The Release workflow has been unable to cut a release. `Semantic Release` fails before doing any work:

```
Error: Missing helper: "conventional-changelog-conventionalcommits requires
conventional-changelog-writer@9 or newer (conventional-changelog@8 or newer).
Your changelog tooling loaded an older writer which cannot render this preset.
Update the tooling or use an older major version of the preset."
```

`extra_plugins` installed `conventional-changelog-conventionalcommits` unpinned, so it resolved to the newest major at install time. From `10.0.0` the preset switched to `@conventional-changelog/template` and requires `conventional-changelog-writer` 9 or newer, while `@semantic-release/release-notes-generator@14` — what semantic-release 25 depends on — still requires writer 8.

Nothing in this repo changed to trigger it: `10.0.0` was published on 2026-06-26, and every run since then picked it up. The dependency is a bare string in `extra_plugins`, so Renovate does not manage it and it never appeared in a bump PR.

> Changelog: skip

## Implementation information

Pinned the preset to `^9.3.1`, the newest release that still targets writer 8, with a comment recording why and when the constraint can be dropped.

Bumping the other side is not currently an option — `@semantic-release/release-notes-generator@14.1.1` is the latest and still declares `conventional-changelog-writer: ^8.0.0`. The pin should be removed once it ships writer 9.

## Supporting documentation

Reproduced both states locally against the same stack the action installs (`semantic-release@25`, `release-notes-generator@14`, `commit-analyzer@13`), calling the plugins directly with the preset this repo configures:

| preset | writer resolved | `generateNotes` |
| :-- | :-- | :-- |
| `10.4.0` (unpinned) | `8.4.0` | fails — the exact `Missing helper` error above |
| `9.3.1` (pinned) | `8.4.0` | renders notes |

`analyzeCommits` also still resolves `feat(x): thing` to a `minor` release with the pinned preset, so version bumping is unaffected.

`actionlint` reports one pre-existing SC2046 warning at line 38, unrelated to this change; it is present on unmodified `main`.
