### PR TITLE
build(mise): fix go commands on a fresh checkout

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -17,10 +17,6 @@ markdownlint-cli2 = "0.23.2"
 # https://onsi.github.io/ginkgo/
 ginkgo = "2.32.1"
 
-# Enum code generator
-# https://github.com/dmarkham/enumer
-"go:github.com/dmarkham/enumer" = "1.6.3"
-
 # Mock generator for Go interfaces
 # https://github.com/uber-go/mock
 "go:go.uber.org/mock/mockgen" = "v0.6.0"

--- a/.mise.toml
+++ b/.mise.toml
@@ -37,8 +37,14 @@ GOTMPDIR = "{{ env.HOME }}/.cache/go-tmp"
 # Tasks
 # ---------------------------------------------------------------------------
 
+[tasks."gotmpdir"]
+description = "Create the Go temp build dir referenced by GOTMPDIR"
+hide = true
+run = 'mkdir -p "$GOTMPDIR"'
+
 [tasks.generate]
 description = "Run all code generation (enums and mocks)"
+depends = ["gotmpdir"]
 run = "go generate ./..."
 sources = [
   "pkg/hook/context.go",
@@ -200,6 +206,7 @@ go test -fuzz=FuzzSecretsDetect -fuzztime="$FUZZ_TIME" ./internal/validators/sec
 
 [tasks.lint]
 description = "Run linters on all files"
+depends = ["gotmpdir"]
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
@@ -209,6 +216,7 @@ golangci-lint run
 
 [tasks."lint:fix"]
 description = "Run linters with auto-fix on all files"
+depends = ["gotmpdir"]
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
@@ -222,6 +230,7 @@ depends = ["lint:fix", "schema:verify"]
 
 [tasks.fmt]
 description = "Format code"
+depends = ["gotmpdir"]
 run = "golangci-lint run --fix"
 
 [tasks.install]

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -8,7 +8,7 @@ import (
 	"github.com/invopop/jsonschema"
 )
 
-//go:generate enumer -type=Severity -trimprefix=Severity -transform=lower -json -text -yaml -sql
+//go:generate go run github.com/dmarkham/enumer -type=Severity -trimprefix=Severity -transform=lower -json -text -yaml -sql
 //go:generate go run github.com/smykla-skalski/klaudiush/tools/enumerfix severity_enumer.go
 
 // jsonSchemaTypeString is the JSON Schema "string" type name.

--- a/pkg/hook/context.go
+++ b/pkg/hook/context.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 )
 
-//go:generate enumer -type=EventType -trimprefix=EventType -json -text -yaml -sql
+//go:generate go run github.com/dmarkham/enumer -type=EventType -trimprefix=EventType -json -text -yaml -sql
 //go:generate go run github.com/smykla-skalski/klaudiush/tools/enumerfix eventtype_enumer.go
-//go:generate enumer -type=ToolType -trimprefix=ToolType -json -text -yaml -sql
+//go:generate go run github.com/dmarkham/enumer -type=ToolType -trimprefix=ToolType -json -text -yaml -sql
 //go:generate go run github.com/smykla-skalski/klaudiush/tools/enumerfix tooltype_enumer.go
 
 // EventType represents the type of hook event.

--- a/pkg/logger/level.go
+++ b/pkg/logger/level.go
@@ -2,7 +2,7 @@ package logger
 
 import "log/slog"
 
-//go:generate enumer -type=Level -trimprefix=Level -transform=upper -json -text -yaml -sql
+//go:generate go run github.com/dmarkham/enumer -type=Level -trimprefix=Level -transform=upper -json -text -yaml -sql
 //go:generate go run github.com/smykla-skalski/klaudiush/tools/enumerfix level_enumer.go
 
 // Level represents the log level.


### PR DESCRIPTION
# Summary

- Enum code generation runs the module-pinned `enumer` rather than a separately built binary, so `go generate ./...` succeeds again
- A hidden mise task creates the Go build temp directory that `[env]` points at, so `go` commands work on a clean machine

## Motivation

Two failures made a fresh checkout unusable, and neither came from a dependency bump. `mise run generate` aborted with `enumer: internal error: package "time" without types was imported from "github.com/smykla-skalski/klaudiush/pkg/config"`. The four enum directives called the `enumer` binary pinned in `.mise.toml`, built against a different `golang.org/x/tools` than the module requires, so its export data reader could not decode the packages. The `enumerfix` directive on those same files already used `go run`, which left one generation step resolving through two toolchains.

The second failure is unrelated to code generation. `[env]` redirects Go build artifacts to a path under the user cache, keeping them clear of the temp location CrowdStrike Falcon scans and deletes, but nothing ever created that path. Every `go` command on a clean machine died with `go: creating work dir: stat ...: no such file or directory`. The three CI workflows create the directory before each Go step, so the gap only hit local development.

## Implementation information

- The four enum directives now run `go run github.com/dmarkham/enumer`, matching the `enumerfix` line beside them and the version in `go.mod`
- The `enumer` pin is gone from `.mise.toml`, since no CI job, hook, or script invokes the binary any more
- A hidden `gotmpdir` task creates the build temp directory, and `generate`, `lint`, `lint:fix`, and `fmt` depend on it
- `build` and the test tasks reach the directory through their existing dependency on `generate`
- `mise run generate` exits 0 and leaves no diff, `mise run lint` reports 0 issues, and the full `mise run test` suite passes
