### PR TITLE
feat(github): reject API calls that create commits

### DIFF
--- a/.claude/validator-error-format-policy.md
+++ b/.claude/validator-error-format-policy.md
@@ -99,10 +99,11 @@ RefShellcheck     Reference = "https://klaudiu.sh/e/FILE001"
 
 - SHELL001: Command substitution in double-quoted strings
 
-**GH001-GH002**: GitHub CLI operations
+**GH001-GH003**: GitHub CLI operations
 
 - GH001: Issue body validation failure (markdown formatting)
 - GH002: `gh api` call to an endpoint that creates a commit outside git
+- GH003: GitHub API write whose endpoint or body cannot be inspected
 
 **PLUG001-PLUG005**: Plugin security
 

--- a/.claude/validator-error-format-policy.md
+++ b/.claude/validator-error-format-policy.md
@@ -99,9 +99,10 @@ RefShellcheck     Reference = "https://klaudiu.sh/e/FILE001"
 
 - SHELL001: Command substitution in double-quoted strings
 
-**GH001**: GitHub CLI operations
+**GH001-GH002**: GitHub CLI operations
 
 - GH001: Issue body validation failure (markdown formatting)
+- GH002: `gh api` call to an endpoint that creates a commit outside git
 
 **PLUG001-PLUG005**: Plugin security
 

--- a/cmd/klaudiush/testdata/scripts/dispatcher/gh_api_contents_blocked.txtar
+++ b/cmd/klaudiush/testdata/scripts/dispatcher/gh_api_contents_blocked.txtar
@@ -1,0 +1,16 @@
+# Test: gh api writing repository contents is blocked
+# The endpoint creates a commit without running git, so no commit validator sees it
+
+stdin input.json
+exec klaudiush --hook-type PreToolUse
+stdout '"permissionDecision":"deny"'
+stdout 'GH002'
+stdout 'git commit -sS'
+
+-- input.json --
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh api --method PUT /repos/owner/repo/contents/README.md -f message=docs -f content=aGk="
+  }
+}

--- a/cmd/klaudiush/testdata/scripts/dispatcher/gh_api_curl_blocked.txtar
+++ b/cmd/klaudiush/testdata/scripts/dispatcher/gh_api_curl_blocked.txtar
@@ -1,0 +1,52 @@
+# Test: the same endpoints are blocked through clients other than gh
+# curl and an inline octokit script reach them without running git
+
+stdin curl_contents.json
+exec klaudiush --hook-type PreToolUse
+stdout '"permissionDecision":"deny"'
+stdout 'GH002'
+
+stdin octokit_script.json
+exec klaudiush --hook-type PreToolUse
+stdout '"permissionDecision":"deny"'
+stdout 'GH002'
+
+stdin curl_read.json
+exec klaudiush --hook-type PreToolUse
+! stdout .
+
+stdin curl_other_host.json
+exec klaudiush --hook-type PreToolUse
+! stdout .
+
+-- curl_contents.json --
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "curl -X PUT https://api.github.com/repos/owner/repo/contents/README.md -d '{\"message\":\"docs\"}'"
+  }
+}
+
+-- octokit_script.json --
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "node -e 'octokit.rest.repos.createOrUpdateFileContents({owner, repo, path})'"
+  }
+}
+
+-- curl_read.json --
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "curl https://api.github.com/repos/owner/repo/contents/README.md"
+  }
+}
+
+-- curl_other_host.json --
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "curl -X PUT https://example.com/repos/owner/repo/contents/README.md -d '{}'"
+  }
+}

--- a/cmd/klaudiush/testdata/scripts/dispatcher/gh_api_graphql_commit_blocked.txtar
+++ b/cmd/klaudiush/testdata/scripts/dispatcher/gh_api_graphql_commit_blocked.txtar
@@ -1,0 +1,16 @@
+# Test: the createCommitOnBranch GraphQL mutation is blocked
+# The path is always /graphql, so the mutation name in the query body is the only signal
+
+stdin input.json
+exec klaudiush --hook-type PreToolUse
+stdout '"permissionDecision":"deny"'
+stdout 'GH002'
+stdout 'createCommitOnBranch'
+
+-- input.json --
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh api graphql -f query='mutation { createCommitOnBranch(input: $input) { commit { url } } }'"
+  }
+}

--- a/cmd/klaudiush/testdata/scripts/dispatcher/gh_api_non_commit_allowed.txtar
+++ b/cmd/klaudiush/testdata/scripts/dispatcher/gh_api_non_commit_allowed.txtar
@@ -1,0 +1,26 @@
+# Test: gh api calls that create no commit pass untouched
+# Creating a branch ref and reading a file are ordinary work
+
+stdin create_ref.json
+exec klaudiush --hook-type PreToolUse
+! stdout .
+
+stdin read_contents.json
+exec klaudiush --hook-type PreToolUse
+! stdout .
+
+-- create_ref.json --
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh api -X POST repos/owner/repo/git/refs -f ref=refs/heads/topic -f sha=deadbeef"
+  }
+}
+
+-- read_contents.json --
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh api repos/owner/repo/contents/README.md --jq .sha"
+  }
+}

--- a/cmd/klaudiush/testdata/scripts/dispatcher/gh_api_opaque_write_blocked.txtar
+++ b/cmd/klaudiush/testdata/scripts/dispatcher/gh_api_opaque_write_blocked.txtar
@@ -1,0 +1,39 @@
+# Test: a write whose endpoint cannot be resolved is blocked under GH003
+# A read through the same variable stays allowed
+
+stdin opaque_write.json
+exec klaudiush --hook-type PreToolUse
+stdout '"permissionDecision":"deny"'
+stdout 'GH003'
+
+stdin opaque_read.json
+exec klaudiush --hook-type PreToolUse
+! stdout .
+
+stdin resolved_write.json
+exec klaudiush --hook-type PreToolUse
+! stdout .
+
+-- opaque_write.json --
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh api -X PUT \"$ENDPOINT\" -f message=docs"
+  }
+}
+
+-- opaque_read.json --
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh api \"$ENDPOINT\" --jq .sha"
+  }
+}
+
+-- resolved_write.json --
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "EP=repos/owner/repo/git/refs; gh api -X POST \"$EP\" -f ref=refs/heads/topic"
+  }
+}

--- a/docs/errors/GH002.md
+++ b/docs/errors/GH002.md
@@ -106,11 +106,15 @@ An endpoint assembled from variables assigned on the same command line is resolv
 
 A `--input` body, and curl's `-d @file`, are read from the file written earlier in the same command line, or from disk when the file already exists. A `gh api` body that cannot be read makes the call unverifiable, which is [GH003](GH003.md).
 
+### Wrapped in a shell
+
+A command line handed to `sh -c`, `bash -c` or a sibling is parsed and checked like any other, up to three levels of nesting, so wrapping a call in a shell does not hide it.
+
 ### What is still not seen
 
 A request made from a separate script file, run as `node script.js` rather than written inline, is invisible: the Bash command carries only the interpreter and the path. Nor is a call assembled at runtime from values the command does not contain.
 
-For clients other than `gh`, a call whose URL cannot be resolved is left alone rather than rejected, because there is no way to tell whether it addresses GitHub at all. The stricter [GH003](GH003.md) applies only to `gh api`, where every request goes to GitHub by definition.
+For clients other than `gh`, a write whose URL cannot be resolved at all is left alone rather than rejected, because there is then no way to tell whether it addresses GitHub. Once the host is known to be GitHub and only the path or body is opaque, [GH003](GH003.md) applies to every client alike.
 
 ## Hook output
 

--- a/docs/errors/GH002.md
+++ b/docs/errors/GH002.md
@@ -1,8 +1,14 @@
-# GH002: gh api call creates a commit
+# GH002: API call creates a commit
 
 ## Error
 
-A `gh api` invocation targets a GitHub endpoint that creates a commit without running git.
+A command calls a GitHub endpoint that creates a commit without running git.
+
+The call is recognised however it is sent:
+
+- `gh api`
+- `curl`, `wget`, `httpie` (`http`/`https`) and `xh`
+- an inline script body, such as `node -e` or `python3 -c`, that calls an API client library
 
 Covered by default:
 
@@ -17,7 +23,7 @@ Covered by default:
 
 klaudiush enforces its commit rules by inspecting `git commit` in Bash. A commit created through the API never runs git, so nothing checks GPG signing, sign-off, the conventional-commit subject, the body line cap, or the ban on PR references. The commit lands unsigned and without a `Signed-off-by` trailer on a repository where both are required.
 
-Calls that create no commit are unaffected: reads of any kind, `POST /repos/{owner}/{repo}/git/refs` to create a branch, and pull request creation all pass.
+Calls that create no commit are unaffected: reads of any kind, `POST /repos/{owner}/{repo}/git/refs` to create a branch, and pull request creation all pass. So does any request to a host that is not the GitHub API.
 
 ## How to fix
 
@@ -69,11 +75,28 @@ blocked_endpoints = [
   "PUT **/pulls/*/merge",
 ]
 blocked_graphql_mutations = ["createCommitOnBranch"]
+block_unverifiable_calls = true
+check_http_clients = true
+hosts = ["api.github.com"]
+blocked_client_calls = [
+  "repos.createOrUpdateFileContents",
+  "repos.deleteFile",
+  "git.createCommit",
+  "repos.merge",
+  "pulls.merge",
+  "createCommitOnBranch",
+]
 ```
 
 Each `blocked_endpoints` entry is a method and a pattern separated by a space. The method may be `*` to match any. The pattern is matched against the endpoint path with the scheme, host, leading slash and query string removed, so `repos/o/r/contents/x`, `/repos/o/r/contents/x` and `https://api.github.com/repos/o/r/contents/x` all match the same rule. A pattern is a glob unless it contains regex syntax.
 
-The effective method follows `gh api` itself: an explicit `-X`/`--method` wins, otherwise the method is `POST` when any field flag (`-f`, `-F`, `--field`, `--raw-field`, `--input`) is present, and `GET` when none is.
+The effective method follows each client's own rules. For `gh api` an explicit `-X`/`--method` wins, otherwise the method is `POST` when any field flag (`-f`, `-F`, `--field`, `--raw-field`, `--input`) is present, and `GET` when none is. For `curl`, `-X`/`--request` wins, `--data` and its variants imply `POST`, `--upload-file` implies `PUT`, and `-I` implies `HEAD`. For `wget`, `--method` wins and `--post-data`/`--post-file` imply `POST`. For httpie and `xh`, a bare verb positional sets the method and request items imply `POST`.
+
+`hosts` names the hostnames treated as the GitHub API when a client other than `gh` sends the request. A path under `/api/v3/` or `/api/graphql` is recognised on any host, which covers GitHub Enterprise Server without listing every instance.
+
+`blocked_client_calls` names API client library methods and matches them only in call form, so `repos.merge(...)` is rejected while a sentence mentioning `repos.merge` is not.
+
+Set `check_http_clients = false` to limit the check to `gh api`.
 
 ### Endpoints built from variables
 
@@ -81,7 +104,13 @@ An endpoint assembled from variables assigned on the same command line is resolv
 
 ### GraphQL bodies in files
 
-A `--input` body is read from the file written earlier in the same command line, or from disk when the file already exists. A body that cannot be read makes the call unverifiable, which is [GH003](GH003.md).
+A `--input` body, and curl's `-d @file`, are read from the file written earlier in the same command line, or from disk when the file already exists. A `gh api` body that cannot be read makes the call unverifiable, which is [GH003](GH003.md).
+
+### What is still not seen
+
+A request made from a separate script file, run as `node script.js` rather than written inline, is invisible: the Bash command carries only the interpreter and the path. Nor is a call assembled at runtime from values the command does not contain.
+
+For clients other than `gh`, a call whose URL cannot be resolved is left alone rather than rejected, because there is no way to tell whether it addresses GitHub at all. The stricter [GH003](GH003.md) applies only to `gh api`, where every request goes to GitHub by definition.
 
 ## Hook output
 
@@ -89,6 +118,8 @@ When this error is triggered, klaudiush writes JSON to stdout:
 
 **permissionDecisionReason** (shown to Claude):
 `[GH002] gh api PUT repos/owner/repo/contents/README.md creates a commit through the GitHub API, bypassing commit validation (GPG signing, sign-off, conventional commit format). Clone the repository, stage the files, and run git commit -sS instead of creating the commit through the GitHub API`
+
+The same call through another client names the tool that sends it, for example `curl PUT repos/owner/repo/contents/README.md creates a commit ...`.
 
 **systemMessage** (shown to user):
 Formatted error with fix hint and reference URL.

--- a/docs/errors/GH002.md
+++ b/docs/errors/GH002.md
@@ -106,9 +106,11 @@ An endpoint assembled from variables assigned on the same command line is resolv
 
 A `--input` body, and curl's `-d @file`, are read from the file written earlier in the same command line, or from disk when the file already exists. A `gh api` body that cannot be read makes the call unverifiable, which is [GH003](GH003.md).
 
-### Wrapped in a shell
+### Wrapped in a shell or a launcher
 
 A command line handed to `sh -c`, `bash -c` or a sibling is parsed and checked like any other, up to three levels of nesting, so wrapping a call in a shell does not hide it.
+
+A launcher that runs another command - `sudo`, `env`, `timeout`, `xargs`, `npx`, `uv run` and their kin - is unwrapped the same way. The first of its arguments that names a command this check knows is taken as the command being launched, so `sudo -u builder gh api …` and `uv run python -c …` are read as the calls they make. A launcher running anything else is left alone.
 
 ### What is still not seen
 

--- a/docs/errors/GH002.md
+++ b/docs/errors/GH002.md
@@ -1,0 +1,102 @@
+# GH002: gh api call creates a commit
+
+## Error
+
+A `gh api` invocation targets a GitHub endpoint that creates a commit without running git.
+
+Covered by default:
+
+- `PUT /repos/{owner}/{repo}/contents/{path}` - create or update a file
+- `DELETE /repos/{owner}/{repo}/contents/{path}` - delete a file
+- `POST /repos/{owner}/{repo}/git/commits` - create a commit object
+- `POST /repos/{owner}/{repo}/merges` - merge a branch
+- `PUT /repos/{owner}/{repo}/pulls/{number}/merge` - merge a pull request
+- the `createCommitOnBranch` GraphQL mutation
+
+## Why this matters
+
+klaudiush enforces its commit rules by inspecting `git commit` in Bash. A commit created through the API never runs git, so nothing checks GPG signing, sign-off, the conventional-commit subject, the body line cap, or the ban on PR references. The commit lands unsigned and without a `Signed-off-by` trailer on a repository where both are required.
+
+Calls that create no commit are unaffected: reads of any kind, `POST /repos/{owner}/{repo}/git/refs` to create a branch, and pull request creation all pass.
+
+## How to fix
+
+Clone the repository, stage the change, and commit with git:
+
+```bash
+git clone https://github.com/owner/repo.git
+cd repo
+git checkout -b feat/my-change
+# edit files
+git add path/to/file
+git commit -sS -m "feat(scope): describe the change"
+git push upstream feat/my-change
+```
+
+If the call is deliberate, use an exception token:
+
+```bash
+gh api --method PUT /repos/owner/repo/contents/README.md -f message=x  # EXC:GH002:Bootstrapping+an+empty+repository
+```
+
+Exceptions need a policy in `.klaudiush/config.toml`:
+
+```toml
+[exceptions.policies.GH002]
+enabled = true
+allow_exception = true
+require_reason = true
+min_reason_length = 10
+```
+
+To turn the check off entirely:
+
+```bash
+klaudiush disable GH002
+```
+
+## Configuration
+
+```toml
+[validators.github.api]
+enabled = true
+severity = "error"
+blocked_endpoints = [
+  "PUT **/contents/**",
+  "DELETE **/contents/**",
+  "POST **/git/commits",
+  "POST **/merges",
+  "PUT **/pulls/*/merge",
+]
+blocked_graphql_mutations = ["createCommitOnBranch"]
+```
+
+Each `blocked_endpoints` entry is a method and a pattern separated by a space. The method may be `*` to match any. The pattern is matched against the endpoint path with the scheme, host, leading slash and query string removed, so `repos/o/r/contents/x`, `/repos/o/r/contents/x` and `https://api.github.com/repos/o/r/contents/x` all match the same rule. A pattern is a glob unless it contains regex syntax.
+
+The effective method follows `gh api` itself: an explicit `-X`/`--method` wins, otherwise the method is `POST` when any field flag (`-f`, `-F`, `--field`, `--raw-field`, `--input`) is present, and `GET` when none is.
+
+### Limitations
+
+An endpoint supplied entirely through one shell variable, such as `gh api "$ENDPOINT"`, cannot be matched. Neither can a GraphQL document read from a file with `--input query.json`; an inline `-f query=...` and a heredoc on stdin both are.
+
+Commits created by tools other than `gh` - a raw `curl` against the same endpoints, or an Octokit script - are out of scope for this check.
+
+## Hook output
+
+When this error is triggered, klaudiush writes JSON to stdout:
+
+**permissionDecisionReason** (shown to Claude):
+`[GH002] gh api PUT repos/owner/repo/contents/README.md creates a commit through the GitHub API, bypassing commit validation (GPG signing, sign-off, conventional commit format). Clone the repository, stage the files, and run git commit -sS instead of creating the commit through the GitHub API`
+
+**systemMessage** (shown to user):
+Formatted error with fix hint and reference URL.
+
+**additionalContext** (behavioral guidance):
+`Automated klaudiush validation check. Fix the reported errors and retry the same command.`
+
+## Related
+
+- [GIT001](GIT001.md) - missing signoff
+- [GIT002](GIT002.md) - missing GPG signature
+- [GIT013](GIT013.md) - invalid conventional commit
+- [GH001](GH001.md) - issue body validation failure

--- a/docs/errors/GH002.md
+++ b/docs/errors/GH002.md
@@ -8,7 +8,7 @@ The call is recognised however it is sent:
 
 - `gh api`
 - `curl`, `wget`, `httpie` (`http`/`https`) and `xh`
-- an inline script body, such as `node -e` or `python3 -c`, that calls an API client library
+- a program handed to a script interpreter, such as `node -e` or `python3 -c`, that calls an API client library
 
 Covered by default:
 
@@ -94,7 +94,7 @@ The effective method follows each client's own rules. For `gh api` an explicit `
 
 `hosts` names the hostnames treated as the GitHub API when a client other than `gh` sends the request. A path under `/api/v3/` or `/api/graphql` is recognised on any host, which covers GitHub Enterprise Server without listing every instance.
 
-`blocked_client_calls` names API client library methods and matches them only in call form, so `repos.merge(...)` is rejected while a sentence mentioning `repos.merge` is not. The match is on the command text, so a command that quotes one of these names in call form - a commit message about `repos.merge(x)`, say - is rejected too. Drop the name from the list, or use an exception token, when that gets in the way.
+`blocked_client_calls` names API client library methods and matches them only in call form, so `repos.merge(...)` is rejected while a sentence mentioning `repos.merge` is not. The match is made only against the program handed to a script interpreter - `node`, `deno`, `bun`, `python`, `ruby`, `perl`, `php`, `sh` and their siblings - in their arguments or on their stdin. Any other command's arguments are data, so a commit message or a PR comment that quotes a call is left alone.
 
 Set `check_http_clients = false` to limit the check to `gh api`.
 

--- a/docs/errors/GH002.md
+++ b/docs/errors/GH002.md
@@ -75,11 +75,13 @@ Each `blocked_endpoints` entry is a method and a pattern separated by a space. T
 
 The effective method follows `gh api` itself: an explicit `-X`/`--method` wins, otherwise the method is `POST` when any field flag (`-f`, `-F`, `--field`, `--raw-field`, `--input`) is present, and `GET` when none is.
 
-### Limitations
+### Endpoints built from variables
 
-An endpoint supplied entirely through one shell variable, such as `gh api "$ENDPOINT"`, cannot be matched. Neither can a GraphQL document read from a file with `--input query.json`; an inline `-f query=...` and a heredoc on stdin both are.
+An endpoint assembled from variables assigned on the same command line is resolved before matching, so `REPO=o/r gh api -X PUT "repos/$REPO/contents/x"` is rejected like the literal form. A write whose endpoint still cannot be resolved is rejected under [GH003](GH003.md) instead.
 
-Commits created by tools other than `gh` - a raw `curl` against the same endpoints, or an Octokit script - are out of scope for this check.
+### GraphQL bodies in files
+
+A `--input` body is read from the file written earlier in the same command line, or from disk when the file already exists. A body that cannot be read makes the call unverifiable, which is [GH003](GH003.md).
 
 ## Hook output
 

--- a/docs/errors/GH002.md
+++ b/docs/errors/GH002.md
@@ -94,7 +94,7 @@ The effective method follows each client's own rules. For `gh api` an explicit `
 
 `hosts` names the hostnames treated as the GitHub API when a client other than `gh` sends the request. A path under `/api/v3/` or `/api/graphql` is recognised on any host, which covers GitHub Enterprise Server without listing every instance.
 
-`blocked_client_calls` names API client library methods and matches them only in call form, so `repos.merge(...)` is rejected while a sentence mentioning `repos.merge` is not.
+`blocked_client_calls` names API client library methods and matches them only in call form, so `repos.merge(...)` is rejected while a sentence mentioning `repos.merge` is not. The match is on the command text, so a command that quotes one of these names in call form - a commit message about `repos.merge(x)`, say - is rejected too. Drop the name from the list, or use an exception token, when that gets in the way.
 
 Set `check_http_clients = false` to limit the check to `gh api`.
 

--- a/docs/errors/GH002.md
+++ b/docs/errors/GH002.md
@@ -94,7 +94,7 @@ The effective method follows each client's own rules. For `gh api` an explicit `
 
 `hosts` names the hostnames treated as the GitHub API when a client other than `gh` sends the request. A path under `/api/v3/` or `/api/graphql` is recognised on any host, which covers GitHub Enterprise Server without listing every instance.
 
-`blocked_client_calls` names API client library methods and matches them only in call form, so `repos.merge(...)` is rejected while a sentence mentioning `repos.merge` is not. The match is made only against the program handed to a script interpreter - `node`, `deno`, `bun`, `python`, `ruby`, `perl`, `php`, `sh` and their siblings - in their arguments or on their stdin. Any other command's arguments are data, so a commit message or a PR comment that quotes a call is left alone.
+`blocked_client_calls` names API client library methods and matches them only in call form, so `repos.merge(...)` is rejected while a sentence mentioning `repos.merge` is not. The match is made only against the program handed to a script interpreter - `node`, `deno`, `bun`, `python`, `ruby`, `perl`, `php` and their siblings - in their arguments or on their stdin. Any other command's arguments are data, so a commit message or a PR comment that quotes a call is left alone. A shell is not scanned this way either: its script is shell source, so it is parsed command by command instead.
 
 Set `check_http_clients = false` to limit the check to `gh api`.
 
@@ -108,7 +108,7 @@ A `--input` body, and curl's `-d @file`, are read from the file written earlier 
 
 ### Wrapped in a shell or a launcher
 
-A command line handed to `sh -c`, `bash -c` or a sibling is parsed and checked like any other, up to three levels of nesting, so wrapping a call in a shell does not hide it.
+A script handed to `sh`, `bash` or a sibling - after `-c`, or on stdin as a heredoc - is parsed and checked like any other command line, up to three levels of nesting, so wrapping a call in a shell does not hide it.
 
 A launcher that runs another command - `sudo`, `env`, `timeout`, `xargs`, `npx`, `uv run` and their kin - is unwrapped the same way. The first of its arguments that names a command this check knows is taken as the command being launched, so `sudo -u builder gh api …` and `uv run python -c …` are read as the calls they make. A launcher running anything else is left alone.
 

--- a/docs/errors/GH003.md
+++ b/docs/errors/GH003.md
@@ -8,6 +8,7 @@ Two cases produce this:
 
 - the endpoint is built from a shell variable that is not assigned in the same command, as in `gh api -X PUT "$ENDPOINT"`
 - a GraphQL query is read from a file that cannot be read, as in `gh api graphql --input query.json` when `query.json` is neither written earlier in the same command nor present on disk
+- a GraphQL query never appears in the command at all, as in `gh api graphql -f query="$(cat mutation.graphql)"`, where the substitution is what supplies it
 
 ## Why this matters
 
@@ -40,6 +41,16 @@ gh api graphql -f query='query { viewer { login } }'
 gh api graphql --input - <<'EOF'
 {"query": "query { viewer { login } }"}
 EOF
+```
+
+Pass the query itself rather than a substitution that produces it:
+
+```bash
+# Instead of this
+gh api graphql -f query="$(cat mutation.graphql)"
+
+# Write this
+gh api graphql --input mutation.graphql
 ```
 
 A file written earlier in the same command line is read, so this also passes:

--- a/docs/errors/GH003.md
+++ b/docs/errors/GH003.md
@@ -1,0 +1,94 @@
+# GH003: GitHub API write cannot be checked
+
+## Error
+
+A `gh api` call changes server state (`POST`, `PUT`, `PATCH` or `DELETE`) but klaudiush cannot see what it targets, so it cannot tell whether the call creates a commit.
+
+Two cases produce this:
+
+- the endpoint is built from a shell variable that is not assigned in the same command, as in `gh api -X PUT "$ENDPOINT"`
+- a GraphQL query is read from a file that cannot be read, as in `gh api graphql --input query.json` when `query.json` is neither written earlier in the same command nor present on disk
+
+## Why this matters
+
+[GH002](GH002.md) rejects the endpoints that create a commit outside git. A call whose target is hidden defeats that check without being obviously wrong, so an opaque write is treated as unproven rather than assumed safe. Reads are never affected: a `GET` through a variable passes.
+
+## How to fix
+
+Spell the endpoint in the command:
+
+```bash
+# Instead of this
+ENDPOINT=$(build_endpoint)
+gh api -X PUT "$ENDPOINT" -f message=x
+
+# Write this
+gh api -X PUT repos/owner/repo/some/endpoint -f message=x
+```
+
+An endpoint assembled from variables assigned in the same command is resolved and passes on its own:
+
+```bash
+REPO=owner/repo gh api -X POST "repos/$REPO/git/refs" -f ref=refs/heads/topic
+```
+
+Pass a GraphQL query inline or on stdin instead of from a file klaudiush cannot read:
+
+```bash
+gh api graphql -f query='query { viewer { login } }'
+
+gh api graphql --input - <<'EOF'
+{"query": "query { viewer { login } }"}
+EOF
+```
+
+A file written earlier in the same command line is read, so this also passes:
+
+```bash
+cat > query.json <<'EOF'
+{"query": "query { viewer { login } }"}
+EOF
+gh api graphql --input query.json
+```
+
+If the call is deliberate, use an exception token:
+
+```bash
+gh api -X PUT "$ENDPOINT"  # EXC:GH003:Endpoint+comes+from+a+generated+manifest
+```
+
+## Configuration
+
+```toml
+[validators.github.api]
+enabled = true
+severity = "error"
+block_unverifiable_calls = true
+```
+
+Set `block_unverifiable_calls = false` to allow writes klaudiush cannot inspect. GH002 still rejects the commit-creating endpoints it can see.
+
+To turn the check off entirely:
+
+```bash
+klaudiush disable GH003
+```
+
+## Hook output
+
+When this error is triggered, klaudiush writes JSON to stdout:
+
+**permissionDecisionReason** (shown to Claude):
+`[GH003] gh api PUT ${ENDPOINT} cannot be checked: the endpoint is not spelled literally, so there is no way to tell whether it creates a commit. Spell the endpoint literally instead of building it from a variable, or pass the GraphQL query inline with -f query=...`
+
+**systemMessage** (shown to user):
+Formatted error with fix hint and reference URL.
+
+**additionalContext** (behavioral guidance):
+`Automated klaudiush validation check. Fix the reported errors and retry the same command.`
+
+## Related
+
+- [GH002](GH002.md) - gh api call creates a commit
+- [GIT001](GIT001.md) - missing signoff
+- [GIT002](GIT002.md) - missing GPG signature

--- a/docs/errors/GH003.md
+++ b/docs/errors/GH003.md
@@ -12,6 +12,8 @@ These cases produce it:
 
 A client other than `gh` reaches this only once its URL is known to address the GitHub API, as in `curl -X PUT "https://api.github.com/$ENDPOINT"` or `curl -X POST https://api.github.com/graphql -d @missing.json`. A write whose URL cannot be resolved at all is left alone, because there is then no way to tell it addresses GitHub rather than any other host.
 
+This catches a shape that is ordinary in CI: `curl -X POST "https://api.github.com/repos/$GITHUB_REPOSITORY/issues"` writes an issue, not a commit, but the path it targets is only known once the variable expands. `gh api` avoids the variable entirely - `gh api -X POST "repos/{owner}/{repo}/issues"` fills the placeholders from the current repository - and is the shortest way out. Otherwise use an exception token on the call, or set `block_unverifiable_calls = false` to accept writes klaudiush cannot inspect.
+
 ## Why this matters
 
 [GH002](GH002.md) rejects the endpoints that create a commit outside git. A call whose target is hidden defeats that check without being obviously wrong, so an opaque write is treated as unproven rather than assumed safe. Reads are never affected: a `GET` through a variable passes.

--- a/docs/errors/GH003.md
+++ b/docs/errors/GH003.md
@@ -2,13 +2,15 @@
 
 ## Error
 
-A `gh api` call changes server state (`POST`, `PUT`, `PATCH` or `DELETE`) but klaudiush cannot see what it targets, so it cannot tell whether the call creates a commit.
+A call to the GitHub API changes server state (`POST`, `PUT`, `PATCH` or `DELETE`) but klaudiush cannot see what it targets, so it cannot tell whether the call creates a commit.
 
-Two cases produce this:
+These cases produce it:
 
 - the endpoint is built from a shell variable that is not assigned in the same command, as in `gh api -X PUT "$ENDPOINT"`
 - a GraphQL query is read from a file that cannot be read, as in `gh api graphql --input query.json` when `query.json` is neither written earlier in the same command nor present on disk
 - a GraphQL query never appears in the command at all, as in `gh api graphql -f query="$(cat mutation.graphql)"`, where the substitution is what supplies it
+
+A client other than `gh` reaches this only once its URL is known to address the GitHub API, as in `curl -X PUT "https://api.github.com/$ENDPOINT"` or `curl -X POST https://api.github.com/graphql -d @missing.json`. A write whose URL cannot be resolved at all is left alone, because there is then no way to tell it addresses GitHub rather than any other host.
 
 ## Why this matters
 

--- a/examples/config/full.toml
+++ b/examples/config/full.toml
@@ -167,7 +167,7 @@ severity = "error"
 # GitHub CLI Validators
 [validators.github]
 
-# gh api Validator - rejects calls to endpoints that create commits outside git
+# GitHub API Validator - rejects calls to endpoints that create commits outside git
 [validators.github.api]
 enabled = true
 severity = "error"
@@ -186,6 +186,21 @@ blocked_graphql_mutations = ["createCommitOnBranch"]
 # Reject a write whose endpoint was built from a variable that cannot be
 # resolved, or whose GraphQL body lives in a file that cannot be read (GH003)
 block_unverifiable_calls = true
+# Apply the same rules to curl, wget, httpie and xh, and to REST calls written
+# inside an inline script body
+check_http_clients = true
+# Hostnames treated as the GitHub API. A path under /api/v3/ or /api/graphql is
+# recognised on any host, covering GitHub Enterprise Server
+hosts = ["api.github.com"]
+# API client library methods that create a commit, matched only in call form
+blocked_client_calls = [
+  "repos.createOrUpdateFileContents",
+  "repos.deleteFile",
+  "git.createCommit",
+  "repos.merge",
+  "pulls.merge",
+  "createCommitOnBranch",
+]
 
 # Notification Validators
 [validators.notification]

--- a/examples/config/full.toml
+++ b/examples/config/full.toml
@@ -183,6 +183,9 @@ blocked_endpoints = [
 ]
 # Mutation names rejected when found in the query body of a /graphql request
 blocked_graphql_mutations = ["createCommitOnBranch"]
+# Reject a write whose endpoint was built from a variable that cannot be
+# resolved, or whose GraphQL body lives in a file that cannot be read (GH003)
+block_unverifiable_calls = true
 
 # Notification Validators
 [validators.notification]

--- a/examples/config/full.toml
+++ b/examples/config/full.toml
@@ -164,6 +164,26 @@ severity = "error"
 # check_unquoted = true          # Detect unquoted backticks (e.g., echo `date`)
 # suggest_single_quotes = true   # Suggest single quotes when no variables present
 
+# GitHub CLI Validators
+[validators.github]
+
+# gh api Validator - rejects calls to endpoints that create commits outside git
+[validators.github.api]
+enabled = true
+severity = "error"
+# Entries are "METHOD path-pattern". The method may be "*". The pattern is
+# matched against the endpoint path with the scheme, host, leading slash and
+# query string removed, and is a glob unless it contains regex syntax.
+blocked_endpoints = [
+  "PUT **/contents/**",
+  "DELETE **/contents/**",
+  "POST **/git/commits",
+  "POST **/merges",
+  "PUT **/pulls/*/merge",
+]
+# Mutation names rejected when found in the query body of a /graphql request
+blocked_graphql_mutations = ["createCommitOnBranch"]
+
 # Notification Validators
 [validators.notification]
 

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -29,7 +29,9 @@ const (
 	sectionNotification = "notification"
 	sectionSecrets      = "secrets"
 	sectionShell        = "shell"
+	sectionGitHub       = "github"
 
+	validatorGHAPI        = "api"
 	validatorCommit       = "commit"
 	validatorPush         = "push"
 	validatorFetch        = "fetch"

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -148,6 +148,7 @@ func DefaultAPIValidatorConfig() *config.APIValidatorConfig {
 		},
 		BlockedEndpoints:        config.DefaultBlockedGHAPIEndpoints(),
 		BlockedGraphQLMutations: config.DefaultBlockedGHAPIMutations(),
+		BlockUnverifiableCalls:  &enabled,
 	}
 }
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -149,6 +149,9 @@ func DefaultAPIValidatorConfig() *config.APIValidatorConfig {
 		BlockedEndpoints:        config.DefaultBlockedGHAPIEndpoints(),
 		BlockedGraphQLMutations: config.DefaultBlockedGHAPIMutations(),
 		BlockUnverifiableCalls:  &enabled,
+		CheckHTTPClients:        &enabled,
+		Hosts:                   config.DefaultGitHubAPIHosts(),
+		BlockedClientCalls:      config.DefaultBlockedGHAPIClientCalls(),
 	}
 }
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -133,6 +133,21 @@ func DefaultGitConfig() *config.GitConfig {
 func DefaultGitHubConfig() *config.GitHubConfig {
 	return &config.GitHubConfig{
 		Issue: DefaultIssueValidatorConfig(),
+		API:   DefaultAPIValidatorConfig(),
+	}
+}
+
+// DefaultAPIValidatorConfig returns the default gh api validator configuration.
+func DefaultAPIValidatorConfig() *config.APIValidatorConfig {
+	enabled := true
+
+	return &config.APIValidatorConfig{
+		ValidatorConfig: config.ValidatorConfig{
+			Enabled:  &enabled,
+			Severity: config.SeverityError, // Commits made this way skip every commit rule
+		},
+		BlockedEndpoints:        config.DefaultBlockedGHAPIEndpoints(),
+		BlockedGraphQLMutations: config.DefaultBlockedGHAPIMutations(),
 	}
 }
 

--- a/internal/config/factory/github_factory.go
+++ b/internal/config/factory/github_factory.go
@@ -22,6 +22,7 @@ const defaultLinterTimeout = 10 * time.Second
 // URL does not pay for a parse.
 const ghAPICommandPattern = `\bgh\s+api\b|(^|[\n|&;(])\s*(curl|wget|https?|xhs?)\b|` +
 	`\b(sh|bash|zsh|ksh|dash)\s+-c\b|` +
+	`\b(sudo|doas|env|command|nice|nohup|timeout|xargs|npx|bunx|uv|pnpm|yarn|poetry|pipx)\s|` +
 	`octokit|\.request\(|api\.github\.com|/api/(v3|graphql)/`
 
 // GitHubValidatorFactory creates GitHub CLI validators from configuration.

--- a/internal/config/factory/github_factory.go
+++ b/internal/config/factory/github_factory.go
@@ -51,7 +51,39 @@ func (f *GitHubValidatorFactory) CreateValidators(cfg *config.Config) []Validato
 		validators = append(validators, f.createIssueValidator(ghCfg.Issue))
 	}
 
+	// API validator - rejects gh api calls that create commits behind the hook.
+	if ghCfg.API != nil && ghCfg.API.IsEnabled() &&
+		!isValidatorOverridden(cfg.Overrides, "github.api") {
+		validators = append(validators, f.createAPIValidator(ghCfg.API))
+	}
+
 	return validators
+}
+
+func (f *GitHubValidatorFactory) createAPIValidator(
+	cfg *config.APIValidatorConfig,
+) ValidatorWithPredicate {
+	var rc validator.RuleChecker
+
+	if f.ruleEngine != nil {
+		rc = rules.NewRuleValidatorAdapter(
+			f.ruleEngine,
+			rules.ValidatorGitHubAPI,
+			rules.WithAdapterLogger(f.log),
+		)
+	}
+
+	return ValidatorWithPredicate{
+		Validator: wrapValidatorWithSeverity(
+			githubvalidators.NewAPIValidator(cfg, f.log, rc),
+			cfg,
+		),
+		Predicate: validator.And(
+			beforeToolOrProviderAfterToolPredicate(),
+			validator.ToolTypeIs(hook.ToolTypeBash),
+			validator.CommandContains("gh api"),
+		),
+	}
 }
 
 func (f *GitHubValidatorFactory) createIssueValidator(

--- a/internal/config/factory/github_factory.go
+++ b/internal/config/factory/github_factory.go
@@ -15,6 +15,12 @@ import (
 
 const defaultLinterTimeout = 10 * time.Second
 
+// ghAPICommandPattern is the cheap prefilter for the gh api validator: the gh
+// api subcommand, the HTTP clients that can reach the same endpoints, and the
+// markers an API client library leaves in an inline script.
+const ghAPICommandPattern = `\bgh\s+api\b|\b(curl|wget|https?|xhs?)\b|` +
+	`octokit|\.request\(|api\.github\.com|/api/(v3|graphql)/`
+
 // GitHubValidatorFactory creates GitHub CLI validators from configuration.
 type GitHubValidatorFactory struct {
 	cfg        *config.Config
@@ -81,7 +87,7 @@ func (f *GitHubValidatorFactory) createAPIValidator(
 		Predicate: validator.And(
 			beforeToolOrProviderAfterToolPredicate(),
 			validator.ToolTypeIs(hook.ToolTypeBash),
-			validator.CommandContains("gh api"),
+			validator.CommandMatches(ghAPICommandPattern),
 		),
 	}
 }

--- a/internal/config/factory/github_factory.go
+++ b/internal/config/factory/github_factory.go
@@ -17,8 +17,10 @@ const defaultLinterTimeout = 10 * time.Second
 
 // ghAPICommandPattern is the cheap prefilter for the gh api validator: the gh
 // api subcommand, the HTTP clients that can reach the same endpoints, and the
-// markers an API client library leaves in an inline script.
-const ghAPICommandPattern = `\bgh\s+api\b|\b(curl|wget|https?|xhs?)\b|` +
+// markers an API client library leaves in an inline script. A client name only
+// counts in command position, so an unrelated command that merely carries a
+// URL does not pay for a parse.
+const ghAPICommandPattern = `\bgh\s+api\b|(^|[\n|&;(])\s*(curl|wget|https?|xhs?)\b|` +
 	`octokit|\.request\(|api\.github\.com|/api/(v3|graphql)/`
 
 // GitHubValidatorFactory creates GitHub CLI validators from configuration.

--- a/internal/config/factory/github_factory.go
+++ b/internal/config/factory/github_factory.go
@@ -21,6 +21,7 @@ const defaultLinterTimeout = 10 * time.Second
 // counts in command position, so an unrelated command that merely carries a
 // URL does not pay for a parse.
 const ghAPICommandPattern = `\bgh\s+api\b|(^|[\n|&;(])\s*(curl|wget|https?|xhs?)\b|` +
+	`\b(sh|bash|zsh|ksh|dash)\s+-c\b|` +
 	`octokit|\.request\(|api\.github\.com|/api/(v3|graphql)/`
 
 // GitHubValidatorFactory creates GitHub CLI validators from configuration.

--- a/internal/config/koanf.go
+++ b/internal/config/koanf.go
@@ -834,6 +834,9 @@ func defaultGHAPIMap() map[string]any {
 		"blocked_endpoints":         config.DefaultBlockedGHAPIEndpoints(),
 		"blocked_graphql_mutations": config.DefaultBlockedGHAPIMutations(),
 		"block_unverifiable_calls":  true,
+		"check_http_clients":        true,
+		"hosts":                     config.DefaultGitHubAPIHosts(),
+		"blocked_client_calls":      config.DefaultBlockedGHAPIClientCalls(),
 	}
 }
 

--- a/internal/config/koanf.go
+++ b/internal/config/koanf.go
@@ -703,7 +703,8 @@ func applyDisableFlags(cfg map[string]any, validatorNames []string) {
 		validatorLinterIgnore: {sectionFile, validatorLinterIgnore},
 		sectionSecrets:        {sectionSecrets, sectionSecrets},
 		validatorBacktick:     {sectionShell, validatorBacktick},
-		"issue":               {"github", "issue"},
+		"issue":               {sectionGitHub, "issue"},
+		validatorGHAPI:        {sectionGitHub, validatorGHAPI},
 		validatorBell:         {sectionNotification, validatorBell},
 	}
 
@@ -815,7 +816,23 @@ func defaultValidatorsMap() map[string]any {
 	return map[string]any{
 		sectionGit:          defaultGitValidatorsMap(),
 		sectionFile:         defaultFileValidatorsMap(),
+		sectionGitHub:       defaultGitHubValidatorsMap(),
 		sectionNotification: defaultNotificationValidatorsMap(),
+	}
+}
+
+func defaultGitHubValidatorsMap() map[string]any {
+	return map[string]any{
+		validatorGHAPI: defaultGHAPIMap(),
+	}
+}
+
+func defaultGHAPIMap() map[string]any {
+	return map[string]any{
+		keyEnabled:                  true,
+		keySeverity:                 severityError,
+		"blocked_endpoints":         config.DefaultBlockedGHAPIEndpoints(),
+		"blocked_graphql_mutations": config.DefaultBlockedGHAPIMutations(),
 	}
 }
 

--- a/internal/config/koanf.go
+++ b/internal/config/koanf.go
@@ -833,6 +833,7 @@ func defaultGHAPIMap() map[string]any {
 		keySeverity:                 severityError,
 		"blocked_endpoints":         config.DefaultBlockedGHAPIEndpoints(),
 		"blocked_graphql_mutations": config.DefaultBlockedGHAPIMutations(),
+		"block_unverifiable_calls":  true,
 	}
 }
 

--- a/internal/patterns/advisor.go
+++ b/internal/patterns/advisor.go
@@ -69,6 +69,7 @@ var codeDescriptions = map[string]string{
 	// GitHub
 	"GH001": "issue validation",
 	"GH002": "gh api commit",
+	"GH003": "unverifiable API write",
 	// Plugin
 	"PLUG001": "path traversal",
 	"PLUG002": "path not allowed",

--- a/internal/patterns/advisor.go
+++ b/internal/patterns/advisor.go
@@ -68,6 +68,7 @@ var codeDescriptions = map[string]string{
 	codeSHELL001: "backtick substitution",
 	// GitHub
 	"GH001": "issue validation",
+	"GH002": "gh api commit",
 	// Plugin
 	"PLUG001": "path traversal",
 	"PLUG002": "path not allowed",

--- a/internal/rules/types.go
+++ b/internal/rules/types.go
@@ -40,6 +40,7 @@ const (
 	ValidatorGitNoVerify      ValidatorType = "git.no_verify"
 	ValidatorGitAll           ValidatorType = "git.*"
 	ValidatorGitHubIssue      ValidatorType = "github.issue"
+	ValidatorGitHubAPI        ValidatorType = "github.api"
 	ValidatorGitHubAll        ValidatorType = "github.*"
 	ValidatorFileMarkdown     ValidatorType = "file.markdown"
 	ValidatorFileShell        ValidatorType = "file.shell"

--- a/internal/validator/reference.go
+++ b/internal/validator/reference.go
@@ -154,6 +154,10 @@ const (
 const (
 	// RefGHIssueValidation indicates gh issue create validation failure (body markdown).
 	RefGHIssueValidation Reference = ReferenceBaseURL + "/GH001"
+
+	// RefGHAPICommit indicates a gh api call that would create a commit
+	// through the GitHub API, outside git and outside the commit validators.
+	RefGHAPICommit Reference = ReferenceBaseURL + "/GH002"
 )
 
 // MCP Elicitation references (MCP001-MCP005).

--- a/internal/validator/reference.go
+++ b/internal/validator/reference.go
@@ -158,6 +158,10 @@ const (
 	// RefGHAPICommit indicates a gh api call that would create a commit
 	// through the GitHub API, outside git and outside the commit validators.
 	RefGHAPICommit Reference = ReferenceBaseURL + "/GH002"
+
+	// RefGHAPIUnverifiable indicates a GitHub API write whose endpoint or
+	// request body could not be read, so it cannot be shown to create no commit.
+	RefGHAPIUnverifiable Reference = ReferenceBaseURL + "/GH003"
 )
 
 // MCP Elicitation references (MCP001-MCP005).

--- a/internal/validator/suggestions.go
+++ b/internal/validator/suggestions.go
@@ -58,6 +58,7 @@ var DefaultSuggestions = map[Reference]string{
 
 	// GitHub CLI suggestions
 	RefGHIssueValidation: "Fix markdown formatting in issue body (empty lines around headings, proper list spacing)",
+	RefGHAPICommit:       "Clone the repository, stage the files, and run git commit -sS instead of creating the commit through the GitHub API",
 
 	// MCP Elicitation suggestions
 	RefMCPServerBlocked:    "Remove MCP server from deny list or use a different server",

--- a/internal/validator/suggestions.go
+++ b/internal/validator/suggestions.go
@@ -59,6 +59,7 @@ var DefaultSuggestions = map[Reference]string{
 	// GitHub CLI suggestions
 	RefGHIssueValidation: "Fix markdown formatting in issue body (empty lines around headings, proper list spacing)",
 	RefGHAPICommit:       "Clone the repository, stage the files, and run git commit -sS instead of creating the commit through the GitHub API",
+	RefGHAPIUnverifiable: "Spell the endpoint literally instead of building it from a variable, or pass the GraphQL query inline with -f query=...",
 
 	// MCP Elicitation suggestions
 	RefMCPServerBlocked:    "Remove MCP server from deny list or use a different server",

--- a/internal/validators/github/api.go
+++ b/internal/validators/github/api.go
@@ -23,16 +23,8 @@ const (
 	// methodWildcard matches any HTTP method in a blocked endpoint rule.
 	methodWildcard = "*"
 
-	// graphqlPath is the normalized endpoint of a GraphQL request.
-	graphqlPath = "graphql"
-
 	// reposPrefix is where every commit-creating REST endpoint lives.
 	reposPrefix = "repos/"
-
-	// ghesRESTPrefix and ghesGraphQLPrefix identify a GitHub Enterprise Server
-	// API path, which can appear on any hostname.
-	ghesRESTPrefix    = "api/v3/"
-	ghesGraphQLPrefix = "api/graphql"
 
 	// maxRequestBodyBytes caps how much of a request body file is read.
 	maxRequestBodyBytes = 1 << 20
@@ -60,9 +52,11 @@ type blockedEndpoint struct {
 // API. Such a commit never runs git, so no commit validator ever sees it.
 type APIValidator struct {
 	validator.BaseValidator
-	config    *config.APIValidatorConfig
-	endpoints []blockedEndpoint
-	mutations []string
+	config      *config.APIValidatorConfig
+	endpoints   []blockedEndpoint
+	mutations   []string
+	hosts       []string
+	clientCalls []string
 }
 
 // NewAPIValidator creates a new APIValidator instance.
@@ -83,6 +77,8 @@ func NewAPIValidator(
 		apiValidator.Logger(),
 	)
 	apiValidator.mutations = apiValidator.blockedMutations()
+	apiValidator.hosts = apiValidator.configuredHosts()
+	apiValidator.clientCalls = apiValidator.blockedClientCalls()
 
 	return apiValidator
 }
@@ -125,8 +121,8 @@ func (v *APIValidator) checksHTTPClients() bool {
 	return true
 }
 
-// hosts returns the hostnames treated as the GitHub API.
-func (v *APIValidator) hosts() []string {
+// configuredHosts returns the hostnames treated as the GitHub API.
+func (v *APIValidator) configuredHosts() []string {
 	if v.config != nil && len(v.config.Hosts) > 0 {
 		return v.config.Hosts
 	}
@@ -242,7 +238,7 @@ func (v *APIValidator) checkAPICommand(
 ) *validator.Result {
 	endpoint := parsed.ExpandVars(apiCmd.Endpoint)
 
-	if apiCmd.IsGraphQL || endpoint == graphqlPath {
+	if apiCmd.IsGraphQL || endpoint == parser.GraphQLEndpoint {
 		return v.checkGraphQL(parsed, apiCmd)
 	}
 
@@ -396,7 +392,7 @@ func (v *APIValidator) checkHTTPRequest(
 
 	endpoint := parser.NormalizeAPIEndpoint(path)
 
-	if endpoint == graphqlPath {
+	if endpoint == parser.GraphQLEndpoint {
 		return v.checkRequestBody(parsed, req)
 	}
 
@@ -443,7 +439,7 @@ func (v *APIValidator) checkScriptText(command string) *validator.Result {
 		return nil
 	}
 
-	if call := parser.FindCallsInText(command, v.blockedClientCalls()); call != "" {
+	if call := parser.FindCallsInText(command, v.clientCalls); call != "" {
 		return v.fail(fmt.Sprintf(
 			"the script calls %s, which creates a commit through the GitHub API, %s",
 			call, bypassExplanation,
@@ -480,12 +476,7 @@ func (v *APIValidator) checkScriptText(command string) *validator.Result {
 // isGitHubAPI reports whether a host and path address the GitHub API. A path
 // under the Enterprise Server prefixes counts on any host.
 func (v *APIValidator) isGitHubAPI(host, path string) bool {
-	if slices.Contains(v.hosts(), host) {
-		return true
-	}
-
-	return strings.HasPrefix(path, "/"+ghesRESTPrefix) ||
-		strings.HasPrefix(path, "/"+ghesGraphQLPrefix)
+	return slices.Contains(v.hosts, host) || parser.IsGHESAPIPath(path)
 }
 
 // blocksEndpoint reports whether a rule rejects this method and endpoint.

--- a/internal/validators/github/api.go
+++ b/internal/validators/github/api.go
@@ -249,7 +249,7 @@ func (v *APIValidator) checkREST(
 	apiCmd *parser.GHAPICommand,
 	endpoint string,
 ) *validator.Result {
-	if blocked := v.matchEndpoint(apiCmd.Method, endpoint); blocked != "" {
+	if v.blocksEndpoint(apiCmd.Method, endpoint) {
 		return v.fail(fmt.Sprintf(
 			"gh api %s %s creates a commit through the GitHub API, %s",
 			apiCmd.Method, endpoint, bypassExplanation,
@@ -370,7 +370,7 @@ func (v *APIValidator) checkHTTPRequest(
 		return v.checkRequestBody(parsed, req)
 	}
 
-	if blocked := v.matchEndpoint(req.Method, endpoint); blocked != "" {
+	if v.blocksEndpoint(req.Method, endpoint) {
 		return v.fail(fmt.Sprintf(
 			"%s %s %s creates a commit through the GitHub API, %s",
 			req.Tool, req.Method, endpoint, bypassExplanation,
@@ -436,7 +436,7 @@ func (v *APIValidator) checkScriptText(command string) *validator.Result {
 			continue
 		}
 
-		if blocked := v.matchEndpoint(req.Method, endpoint); blocked != "" {
+		if v.blocksEndpoint(req.Method, endpoint) {
 			return v.fail(fmt.Sprintf(
 				"the script sends %s %s, which creates a commit through the GitHub API, %s",
 				req.Method, endpoint, bypassExplanation,
@@ -458,19 +458,19 @@ func (v *APIValidator) isGitHubAPI(host, path string) bool {
 		strings.HasPrefix(path, "/"+ghesGraphQLPrefix)
 }
 
-// matchEndpoint returns the rule that blocks the request, or an empty string.
-func (v *APIValidator) matchEndpoint(method, endpoint string) string {
+// blocksEndpoint reports whether a rule rejects this method and endpoint.
+func (v *APIValidator) blocksEndpoint(method, endpoint string) bool {
 	for _, blocked := range v.endpoints {
 		if blocked.method != methodWildcard && blocked.method != method {
 			continue
 		}
 
 		if blocked.pattern.Match(endpoint) {
-			return blocked.method + " " + blocked.pattern.String()
+			return true
 		}
 	}
 
-	return ""
+	return false
 }
 
 // matchMutation returns the blocked mutation found in a GraphQL body.

--- a/internal/validators/github/api.go
+++ b/internal/validators/github/api.go
@@ -48,6 +48,8 @@ const (
 // scriptInterpreters run a program given in their arguments or on their stdin.
 // Only their text is scanned for an API call: any other command's arguments are
 // data, and a commit message or a PR comment that quotes a call is not one.
+// Shells are not among them - their script is shell source, so it is parsed
+// rather than scanned. See shellInterpreters.
 var scriptInterpreters = map[string]bool{
 	"node":      true,
 	"nodejs":    true,
@@ -62,11 +64,6 @@ var scriptInterpreters = map[string]bool{
 	"perl":      true,
 	"php":       true,
 	"osascript": true,
-	"sh":        true,
-	"bash":      true,
-	"zsh":       true,
-	"ksh":       true,
-	"dash":      true,
 }
 
 // commandLaunchers run another command named in their arguments. Rather than
@@ -96,8 +93,8 @@ var commandLaunchers = map[string]bool{
 	"pipx":    true,
 }
 
-// shellInterpreters run a command line handed to them after -c, so that script
-// is parsed and checked like any other command line.
+// shellInterpreters run a command line handed to them after -c or on stdin, so
+// that script is parsed and checked like any other command line.
 var shellInterpreters = map[string]bool{
 	"sh":   true,
 	"bash": true,
@@ -300,12 +297,14 @@ func (v *APIValidator) checkCommand(
 
 		return nil
 
-	case v.checksHTTPClients() && scriptInterpreters[cmd.Name]:
-		if result := v.checkScriptText(scriptText(cmd)); result != nil {
-			return result
-		}
-
+	// A shell is handed shell source, which is parsed and checked command by
+	// command. Scanning that same text for a call name could only add false
+	// positives: an echo or a commit message inside the script is data.
+	case v.checksHTTPClients() && shellInterpreters[cmd.Name]:
 		return v.checkShellScript(cmd, depth)
+
+	case v.checksHTTPClients() && scriptInterpreters[cmd.Name]:
+		return v.checkScriptText(scriptText(cmd))
 
 	default:
 		return nil
@@ -347,7 +346,7 @@ func (v *APIValidator) isCheckedCommand(name string) bool {
 		return false
 	}
 
-	return parser.IsHTTPClientName(name) || scriptInterpreters[name]
+	return parser.IsHTTPClientName(name) || scriptInterpreters[name] || shellInterpreters[name]
 }
 
 // scriptText is the program an interpreter was handed, whether it arrived in
@@ -356,26 +355,31 @@ func scriptText(cmd parser.Command) string {
 	return strings.Join(cmd.Args, " ") + "\n" + cmd.Stdin
 }
 
-// checkShellScript parses the command line a shell was given after -c and
-// checks it, so wrapping a call in sh -c does not hide it.
+// checkShellScript parses the script a shell was given, after -c or on stdin,
+// and checks it, so wrapping a call in sh -c does not hide it.
 func (v *APIValidator) checkShellScript(cmd parser.Command, depth int) *validator.Result {
-	if depth >= maxScriptDepth || !shellInterpreters[cmd.Name] {
+	if depth >= maxScriptDepth {
 		return nil
 	}
 
-	script := shellScriptArg(cmd)
-	if script == "" {
-		return nil
+	for _, script := range []string{shellScriptArg(cmd), cmd.Stdin} {
+		if script == "" {
+			continue
+		}
+
+		inner, err := parser.NewBashParser().Parse(script)
+		if err != nil {
+			v.Logger().Debug("Cannot parse shell script", "error", err)
+
+			continue
+		}
+
+		if result := v.checkParsed(inner, depth+1); result != nil {
+			return result
+		}
 	}
 
-	inner, err := parser.NewBashParser().Parse(script)
-	if err != nil {
-		v.Logger().Debug("Cannot parse shell script argument", "error", err)
-
-		return nil
-	}
-
-	return v.checkParsed(inner, depth+1)
+	return nil
 }
 
 // shellScriptArg returns the command line a shell was given after -c.

--- a/internal/validators/github/api.go
+++ b/internal/validators/github/api.go
@@ -69,6 +69,33 @@ var scriptInterpreters = map[string]bool{
 	"dash":      true,
 }
 
+// commandLaunchers run another command named in their arguments. Rather than
+// model each one's own flags, the first argument naming a command this
+// validator checks is taken as the command being launched, which resolves
+// "sudo -u u gh api", "env FOO=1 gh api", "timeout 30 curl" and "uv run python"
+// alike. A launcher running anything else is left alone.
+var commandLaunchers = map[string]bool{
+	"sudo":    true,
+	"doas":    true,
+	"env":     true,
+	"command": true,
+	"nice":    true,
+	"ionice":  true,
+	"nohup":   true,
+	"stdbuf":  true,
+	"timeout": true,
+	"xargs":   true,
+	"time":    true,
+	"watch":   true,
+	"npx":     true,
+	"bunx":    true,
+	"pnpm":    true,
+	"yarn":    true,
+	"uv":      true,
+	"poetry":  true,
+	"pipx":    true,
+}
+
 // shellInterpreters run a command line handed to them after -c, so that script
 // is parsed and checked like any other command line.
 var shellInterpreters = map[string]bool{
@@ -249,6 +276,10 @@ func (v *APIValidator) checkCommand(
 	cmd parser.Command,
 	depth int,
 ) *validator.Result {
+	if inner, launched := v.unwrapLauncher(cmd); launched && depth < maxScriptDepth {
+		return v.checkCommand(parsed, inner, depth+1)
+	}
+
 	switch {
 	case parser.IsGHAPI(&cmd):
 		apiCmd, err := parser.ParseGHAPICommand(cmd)
@@ -279,6 +310,44 @@ func (v *APIValidator) checkCommand(
 	default:
 		return nil
 	}
+}
+
+// unwrapLauncher returns the command a launcher runs, when one of the commands
+// this validator checks appears among its arguments.
+func (v *APIValidator) unwrapLauncher(cmd parser.Command) (parser.Command, bool) {
+	if !commandLaunchers[cmd.Name] {
+		return parser.Command{}, false
+	}
+
+	for i, arg := range cmd.Args {
+		if !v.isCheckedCommand(arg) {
+			continue
+		}
+
+		return parser.Command{
+			Name:             arg,
+			Args:             cmd.Args[i+1:],
+			Type:             cmd.Type,
+			Stdin:            cmd.Stdin,
+			WorkingDirectory: cmd.WorkingDirectory,
+			Location:         cmd.Location,
+		}, true
+	}
+
+	return parser.Command{}, false
+}
+
+// isCheckedCommand reports whether a name is one this validator inspects.
+func (v *APIValidator) isCheckedCommand(name string) bool {
+	if name == ghCommand {
+		return true
+	}
+
+	if !v.checksHTTPClients() {
+		return false
+	}
+
+	return parser.IsHTTPClientName(name) || scriptInterpreters[name]
 }
 
 // scriptText is the program an interpreter was handed, whether it arrived in

--- a/internal/validators/github/api.go
+++ b/internal/validators/github/api.go
@@ -3,6 +3,8 @@ package github
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/smykla-skalski/klaudiush/internal/rules"
@@ -19,6 +21,9 @@ const (
 	// methodWildcard matches any HTTP method in a blocked endpoint rule.
 	methodWildcard = "*"
 
+	// graphqlPath is the normalized endpoint of a GraphQL request.
+	graphqlPath = "graphql"
+
 	// bypassExplanation names what a commit made this way skips.
 	bypassExplanation = "bypassing commit validation (GPG signing, sign-off, conventional commit format)"
 
@@ -26,6 +31,10 @@ const (
 	apiHelp = "Clone the repository, stage the change, and commit with git commit -sS. " +
 		"gh api calls that create no commit are unaffected: reads, " +
 		"POST /repos/{owner}/{repo}/git/refs, gh pr create."
+
+	// unverifiableHelp tells the caller how to make the call checkable.
+	unverifiableHelp = "Spell the endpoint literally in the command, or pass the GraphQL query " +
+		"with -f query=... or on stdin, so klaudiush can tell whether it creates a commit."
 )
 
 // blockedEndpoint pairs an HTTP method with a compiled endpoint pattern.
@@ -81,6 +90,17 @@ func (v *APIValidator) blockedMutations() []string {
 	}
 
 	return config.DefaultBlockedGHAPIMutations()
+}
+
+// blocksUnverifiable reports whether a write whose endpoint or GraphQL body
+// cannot be read is rejected. Default: true, since an opaque write to the
+// GitHub API cannot be shown to be safe.
+func (v *APIValidator) blocksUnverifiable() bool {
+	if v.config != nil && v.config.BlockUnverifiableCalls != nil {
+		return *v.config.BlockUnverifiableCalls
+	}
+
+	return true
 }
 
 // compileBlockedEndpoints turns "METHOD pattern" rules into matchers. A rule
@@ -142,7 +162,7 @@ func (v *APIValidator) Validate(ctx context.Context, hookCtx *hook.Context) *val
 			continue
 		}
 
-		if result := v.checkAPICommand(apiCmd); result != nil {
+		if result := v.checkAPICommand(parsed, apiCmd); result != nil {
 			return result
 		}
 	}
@@ -153,43 +173,96 @@ func (v *APIValidator) Validate(ctx context.Context, hookCtx *hook.Context) *val
 }
 
 // checkAPICommand returns a failure when the call creates a commit, nil otherwise.
-func (v *APIValidator) checkAPICommand(apiCmd *parser.GHAPICommand) *validator.Result {
-	if apiCmd.IsGraphQL {
-		return v.checkGraphQL(apiCmd)
+func (v *APIValidator) checkAPICommand(
+	parsed *parser.ParseResult,
+	apiCmd *parser.GHAPICommand,
+) *validator.Result {
+	endpoint := parsed.ExpandVars(apiCmd.Endpoint)
+
+	if apiCmd.IsGraphQL || endpoint == graphqlPath {
+		return v.checkGraphQL(parsed, apiCmd)
 	}
 
-	return v.checkREST(apiCmd)
+	return v.checkREST(apiCmd, endpoint)
 }
 
 // checkREST matches the request against the blocked endpoint rules.
-func (v *APIValidator) checkREST(apiCmd *parser.GHAPICommand) *validator.Result {
-	if apiCmd.Endpoint == "" {
-		return nil
-	}
-
+func (v *APIValidator) checkREST(
+	apiCmd *parser.GHAPICommand,
+	endpoint string,
+) *validator.Result {
 	for _, blocked := range v.endpoints {
 		if blocked.method != methodWildcard && blocked.method != apiCmd.Method {
 			continue
 		}
 
-		if !blocked.pattern.Match(apiCmd.Endpoint) {
+		if !blocked.pattern.Match(endpoint) {
 			continue
 		}
 
 		return v.fail(fmt.Sprintf(
 			"gh api %s %s creates a commit through the GitHub API, %s",
-			apiCmd.Method, apiCmd.Endpoint, bypassExplanation,
+			apiCmd.Method, endpoint, bypassExplanation,
+		))
+	}
+
+	if v.isOpaqueWrite(apiCmd, endpoint) {
+		return v.failUnverifiable(fmt.Sprintf(
+			"gh api %s %s cannot be checked: the endpoint is not spelled literally, "+
+				"so there is no way to tell whether it creates a commit",
+			apiCmd.Method, describeEndpoint(endpoint),
 		))
 	}
 
 	return nil
 }
 
+// isOpaqueWrite reports whether the call changes server state through an
+// endpoint that could not be resolved to a literal path.
+func (v *APIValidator) isOpaqueWrite(apiCmd *parser.GHAPICommand, endpoint string) bool {
+	if !v.blocksUnverifiable() || !apiCmd.IsWriteMethod() {
+		return false
+	}
+
+	return endpoint == "" || parser.HasUnresolvedVars(endpoint)
+}
+
+// describeEndpoint renders an endpoint for a message, naming the empty case.
+func describeEndpoint(endpoint string) string {
+	if endpoint == "" {
+		return "(no endpoint in the command)"
+	}
+
+	return endpoint
+}
+
 // checkGraphQL matches the mutation name inside the query body, since the path
 // is always /graphql and carries no signal.
-func (v *APIValidator) checkGraphQL(apiCmd *parser.GHAPICommand) *validator.Result {
+func (v *APIValidator) checkGraphQL(
+	parsed *parser.ParseResult,
+	apiCmd *parser.GHAPICommand,
+) *validator.Result {
+	query := apiCmd.Query
+
+	if apiCmd.InputFile != "" {
+		body, ok := v.readInputFile(parsed, apiCmd)
+		if !ok {
+			if !v.blocksUnverifiable() {
+				return nil
+			}
+
+			return v.failUnverifiable(fmt.Sprintf(
+				"gh api graphql reads its query from %s, which cannot be read, "+
+					"so there is no way to tell whether it creates a commit",
+				apiCmd.InputFile,
+			))
+		}
+
+		query += "\n" + body
+	}
+
 	for _, mutation := range v.mutations {
-		if !strings.Contains(apiCmd.Query, mutation) {
+		if !strings.Contains(query, mutation) {
 			continue
 		}
 
@@ -203,8 +276,42 @@ func (v *APIValidator) checkGraphQL(apiCmd *parser.GHAPICommand) *validator.Resu
 	return nil
 }
 
+// readInputFile returns the --input body, preferring content written earlier in
+// the same command line over what is on disk, since a file created by a heredoc
+// does not exist yet when the PreToolUse hook runs.
+func (v *APIValidator) readInputFile(
+	parsed *parser.ParseResult,
+	apiCmd *parser.GHAPICommand,
+) (string, bool) {
+	if content, ok := parsed.InlineFileContent(
+		apiCmd.InputFile, apiCmd.WorkingDirectory, apiCmd.Location,
+	); ok {
+		return content, true
+	}
+
+	path := apiCmd.InputFile
+	if !filepath.IsAbs(path) && apiCmd.WorkingDirectory != "" {
+		path = filepath.Join(apiCmd.WorkingDirectory, path)
+	}
+
+	content, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		v.Logger().Debug("Cannot read gh api input file", "path", path, "error", err)
+
+		return "", false
+	}
+
+	return string(content), true
+}
+
 // fail builds the blocking result. FixHint comes from the suggestions registry.
 func (*APIValidator) fail(message string) *validator.Result {
 	return validator.FailWithRef(validator.RefGHAPICommit, message).
 		AddDetail("help", apiHelp)
+}
+
+// failUnverifiable blocks a write that cannot be shown to be safe.
+func (*APIValidator) failUnverifiable(message string) *validator.Result {
+	return validator.FailWithRef(validator.RefGHAPIUnverifiable, message).
+		AddDetail("help", unverifiableHelp)
 }

--- a/internal/validators/github/api.go
+++ b/internal/validators/github/api.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/smykla-skalski/klaudiush/internal/rules"
@@ -24,12 +25,20 @@ const (
 	// graphqlPath is the normalized endpoint of a GraphQL request.
 	graphqlPath = "graphql"
 
+	// reposPrefix is where every commit-creating REST endpoint lives.
+	reposPrefix = "repos/"
+
+	// ghesRESTPrefix and ghesGraphQLPrefix identify a GitHub Enterprise Server
+	// API path, which can appear on any hostname.
+	ghesRESTPrefix    = "api/v3/"
+	ghesGraphQLPrefix = "api/graphql"
+
 	// bypassExplanation names what a commit made this way skips.
 	bypassExplanation = "bypassing commit validation (GPG signing, sign-off, conventional commit format)"
 
 	// apiHelp names the intended path, so the refusal is not just a "no".
 	apiHelp = "Clone the repository, stage the change, and commit with git commit -sS. " +
-		"gh api calls that create no commit are unaffected: reads, " +
+		"API calls that create no commit are unaffected: reads, " +
 		"POST /repos/{owner}/{repo}/git/refs, gh pr create."
 
 	// unverifiableHelp tells the caller how to make the call checkable.
@@ -103,6 +112,33 @@ func (v *APIValidator) blocksUnverifiable() bool {
 	return true
 }
 
+// checksHTTPClients reports whether clients other than gh are inspected.
+func (v *APIValidator) checksHTTPClients() bool {
+	if v.config != nil && v.config.CheckHTTPClients != nil {
+		return *v.config.CheckHTTPClients
+	}
+
+	return true
+}
+
+// hosts returns the hostnames treated as the GitHub API.
+func (v *APIValidator) hosts() []string {
+	if v.config != nil && len(v.config.Hosts) > 0 {
+		return v.config.Hosts
+	}
+
+	return config.DefaultGitHubAPIHosts()
+}
+
+// blockedClientCalls returns the library method names that create a commit.
+func (v *APIValidator) blockedClientCalls() []string {
+	if v.config != nil && len(v.config.BlockedClientCalls) > 0 {
+		return v.config.BlockedClientCalls
+	}
+
+	return config.DefaultBlockedGHAPIClientCalls()
+}
+
 // compileBlockedEndpoints turns "METHOD pattern" rules into matchers. A rule
 // that does not compile is skipped rather than failing the whole hook.
 func compileBlockedEndpoints(specs []string, log logger.Logger) []blockedEndpoint {
@@ -151,25 +187,47 @@ func (v *APIValidator) Validate(ctx context.Context, hookCtx *hook.Context) *val
 	}
 
 	for _, cmd := range parsed.Commands {
-		if !parser.IsGHAPI(&cmd) {
-			continue
-		}
-
-		apiCmd, parseErr := parser.ParseGHAPICommand(cmd)
-		if parseErr != nil {
-			log.Debug("Skipping unparseable gh api command", "error", parseErr)
-
-			continue
-		}
-
-		if result := v.checkAPICommand(parsed, apiCmd); result != nil {
+		if result := v.checkCommand(parsed, cmd); result != nil {
 			return result
 		}
 	}
 
-	log.Debug("No commit-creating gh api commands found")
+	if result := v.checkScriptText(hookCtx.GetCommand()); result != nil {
+		return result
+	}
+
+	log.Debug("No commit-creating API calls found")
 
 	return validator.Pass()
+}
+
+// checkCommand dispatches one parsed command to the matching request source.
+func (v *APIValidator) checkCommand(
+	parsed *parser.ParseResult,
+	cmd parser.Command,
+) *validator.Result {
+	switch {
+	case parser.IsGHAPI(&cmd):
+		apiCmd, err := parser.ParseGHAPICommand(cmd)
+		if err != nil {
+			v.Logger().Debug("Skipping unparseable gh api command", "error", err)
+
+			return nil
+		}
+
+		return v.checkAPICommand(parsed, apiCmd)
+
+	case v.checksHTTPClients() && parser.IsHTTPClient(&cmd):
+		req, ok := parser.ParseHTTPClientCommand(cmd)
+		if !ok {
+			return nil
+		}
+
+		return v.checkHTTPRequest(parsed, req)
+
+	default:
+		return nil
+	}
 }
 
 // checkAPICommand returns a failure when the call creates a commit, nil otherwise.
@@ -191,15 +249,7 @@ func (v *APIValidator) checkREST(
 	apiCmd *parser.GHAPICommand,
 	endpoint string,
 ) *validator.Result {
-	for _, blocked := range v.endpoints {
-		if blocked.method != methodWildcard && blocked.method != apiCmd.Method {
-			continue
-		}
-
-		if !blocked.pattern.Match(endpoint) {
-			continue
-		}
-
+	if blocked := v.matchEndpoint(apiCmd.Method, endpoint); blocked != "" {
 		return v.fail(fmt.Sprintf(
 			"gh api %s %s creates a commit through the GitHub API, %s",
 			apiCmd.Method, endpoint, bypassExplanation,
@@ -245,7 +295,9 @@ func (v *APIValidator) checkGraphQL(
 	query := apiCmd.Query
 
 	if apiCmd.InputFile != "" {
-		body, ok := v.readInputFile(parsed, apiCmd)
+		body, ok := v.readFile(
+			parsed, apiCmd.InputFile, apiCmd.WorkingDirectory, apiCmd.Location,
+		)
 		if !ok {
 			if !v.blocksUnverifiable() {
 				return nil
@@ -261,11 +313,7 @@ func (v *APIValidator) checkGraphQL(
 		query += "\n" + body
 	}
 
-	for _, mutation := range v.mutations {
-		if !strings.Contains(query, mutation) {
-			continue
-		}
-
+	if mutation := v.matchMutation(query); mutation != "" {
 		return v.fail(fmt.Sprintf(
 			"gh api graphql calls the %s mutation, which creates a commit through the GitHub API, %s",
 			mutation,
@@ -276,32 +324,164 @@ func (v *APIValidator) checkGraphQL(
 	return nil
 }
 
-// readInputFile returns the --input body, preferring content written earlier in
-// the same command line over what is on disk, since a file created by a heredoc
-// does not exist yet when the PreToolUse hook runs.
-func (v *APIValidator) readInputFile(
+// readFile returns a request body from a file, preferring content written
+// earlier in the same command line over what is on disk, since a file created
+// by a heredoc does not exist yet when the PreToolUse hook runs.
+func (v *APIValidator) readFile(
 	parsed *parser.ParseResult,
-	apiCmd *parser.GHAPICommand,
+	filePath, workDir string,
+	location parser.Location,
 ) (string, bool) {
-	if content, ok := parsed.InlineFileContent(
-		apiCmd.InputFile, apiCmd.WorkingDirectory, apiCmd.Location,
-	); ok {
+	if content, ok := parsed.InlineFileContent(filePath, workDir, location); ok {
 		return content, true
 	}
 
-	path := apiCmd.InputFile
-	if !filepath.IsAbs(path) && apiCmd.WorkingDirectory != "" {
-		path = filepath.Join(apiCmd.WorkingDirectory, path)
+	path := filePath
+	if !filepath.IsAbs(path) && workDir != "" {
+		path = filepath.Join(workDir, path)
 	}
 
 	content, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
-		v.Logger().Debug("Cannot read gh api input file", "path", path, "error", err)
+		v.Logger().Debug("Cannot read API request body file", "path", path, "error", err)
 
 		return "", false
 	}
 
 	return string(content), true
+}
+
+// checkHTTPRequest applies the same endpoint rules to a curl, wget, httpie or
+// xh call, once its URL is shown to address the GitHub API.
+func (v *APIValidator) checkHTTPRequest(
+	parsed *parser.ParseResult,
+	req *parser.HTTPRequest,
+) *validator.Result {
+	url := parsed.ExpandVars(req.URL)
+
+	host, path := parser.SplitURL(url)
+	if !v.isGitHubAPI(host, path) {
+		return nil
+	}
+
+	endpoint := parser.NormalizeAPIEndpoint(url)
+
+	if endpoint == graphqlPath {
+		return v.checkRequestBody(parsed, req)
+	}
+
+	if blocked := v.matchEndpoint(req.Method, endpoint); blocked != "" {
+		return v.fail(fmt.Sprintf(
+			"%s %s %s creates a commit through the GitHub API, %s",
+			req.Tool, req.Method, endpoint, bypassExplanation,
+		))
+	}
+
+	return nil
+}
+
+// checkRequestBody looks for a commit-creating mutation in a GraphQL body sent
+// by a client other than gh.
+func (v *APIValidator) checkRequestBody(
+	parsed *parser.ParseResult,
+	req *parser.HTTPRequest,
+) *validator.Result {
+	body := req.Body
+
+	if req.BodyFile != "" {
+		if content, ok := v.readFile(parsed, req.BodyFile, req.WorkingDirectory, req.Location); ok {
+			body += "\n" + content
+		}
+	}
+
+	if mutation := v.matchMutation(body); mutation != "" {
+		return v.fail(fmt.Sprintf(
+			"%s sends the %s mutation to the GitHub GraphQL API, "+
+				"which creates a commit, %s",
+			req.Tool, mutation, bypassExplanation,
+		))
+	}
+
+	return nil
+}
+
+// checkScriptText looks for API calls written inside an inline script body, so
+// a request made from node -e or python -c is seen even though the command
+// itself is only an interpreter invocation.
+func (v *APIValidator) checkScriptText(command string) *validator.Result {
+	if !v.checksHTTPClients() {
+		return nil
+	}
+
+	if call := parser.FindCallsInText(command, v.blockedClientCalls()); call != "" {
+		return v.fail(fmt.Sprintf(
+			"the script calls %s, which creates a commit through the GitHub API, %s",
+			call, bypassExplanation,
+		))
+	}
+
+	for _, req := range parser.FindAPICallsInText(command) {
+		endpoint := parser.NormalizeAPIEndpoint(req.URL)
+
+		host, path := parser.SplitURL(req.URL)
+		if host != "" {
+			if !v.isGitHubAPI(host, path) {
+				continue
+			}
+		} else if !req.ExplicitAPICall || !strings.HasPrefix(endpoint, reposPrefix) {
+			// A path with no host is only a GitHub call when the syntax names
+			// an API client and the path sits under repos/, where every
+			// commit-creating REST endpoint lives. Anything else is as likely
+			// to be a local route in the same script.
+			continue
+		}
+
+		if blocked := v.matchEndpoint(req.Method, endpoint); blocked != "" {
+			return v.fail(fmt.Sprintf(
+				"the script sends %s %s, which creates a commit through the GitHub API, %s",
+				req.Method, endpoint, bypassExplanation,
+			))
+		}
+	}
+
+	return nil
+}
+
+// isGitHubAPI reports whether a host and path address the GitHub API. A path
+// under the Enterprise Server prefixes counts on any host.
+func (v *APIValidator) isGitHubAPI(host, path string) bool {
+	if slices.Contains(v.hosts(), host) {
+		return true
+	}
+
+	return strings.HasPrefix(path, "/"+ghesRESTPrefix) ||
+		strings.HasPrefix(path, "/"+ghesGraphQLPrefix)
+}
+
+// matchEndpoint returns the rule that blocks the request, or an empty string.
+func (v *APIValidator) matchEndpoint(method, endpoint string) string {
+	for _, blocked := range v.endpoints {
+		if blocked.method != methodWildcard && blocked.method != method {
+			continue
+		}
+
+		if blocked.pattern.Match(endpoint) {
+			return blocked.method + " " + blocked.pattern.String()
+		}
+	}
+
+	return ""
+}
+
+// matchMutation returns the blocked mutation found in a GraphQL body.
+func (v *APIValidator) matchMutation(body string) string {
+	for _, mutation := range v.mutations {
+		if strings.Contains(body, mutation) {
+			return mutation
+		}
+	}
+
+	return ""
 }
 
 // fail builds the blocking result. FixHint comes from the suggestions registry.

--- a/internal/validators/github/api.go
+++ b/internal/validators/github/api.go
@@ -1,0 +1,210 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/smykla-skalski/klaudiush/internal/rules"
+	"github.com/smykla-skalski/klaudiush/internal/validator"
+	"github.com/smykla-skalski/klaudiush/pkg/config"
+	"github.com/smykla-skalski/klaudiush/pkg/hook"
+	"github.com/smykla-skalski/klaudiush/pkg/logger"
+	"github.com/smykla-skalski/klaudiush/pkg/parser"
+)
+
+const (
+	apiValidatorName = "validate-gh-api"
+
+	// methodWildcard matches any HTTP method in a blocked endpoint rule.
+	methodWildcard = "*"
+
+	// bypassExplanation names what a commit made this way skips.
+	bypassExplanation = "bypassing commit validation (GPG signing, sign-off, conventional commit format)"
+
+	// apiHelp names the intended path, so the refusal is not just a "no".
+	apiHelp = "Clone the repository, stage the change, and commit with git commit -sS. " +
+		"gh api calls that create no commit are unaffected: reads, " +
+		"POST /repos/{owner}/{repo}/git/refs, gh pr create."
+)
+
+// blockedEndpoint pairs an HTTP method with a compiled endpoint pattern.
+type blockedEndpoint struct {
+	method  string
+	pattern rules.Pattern
+}
+
+// APIValidator rejects gh api calls that create a commit through the GitHub
+// API. Such a commit never runs git, so no commit validator ever sees it.
+type APIValidator struct {
+	validator.BaseValidator
+	config    *config.APIValidatorConfig
+	endpoints []blockedEndpoint
+	mutations []string
+}
+
+// NewAPIValidator creates a new APIValidator instance.
+func NewAPIValidator(
+	cfg *config.APIValidatorConfig,
+	log logger.Logger,
+	ruleAdapter validator.RuleChecker,
+) *APIValidator {
+	apiValidator := &APIValidator{
+		BaseValidator: *validator.NewBaseValidatorWithRules(
+			apiValidatorName, log, ruleAdapter,
+		),
+		config: cfg,
+	}
+
+	apiValidator.endpoints = compileBlockedEndpoints(
+		apiValidator.blockedEndpointRules(),
+		apiValidator.Logger(),
+	)
+	apiValidator.mutations = apiValidator.blockedMutations()
+
+	return apiValidator
+}
+
+// blockedEndpointRules returns the configured endpoint rules, or the defaults.
+func (v *APIValidator) blockedEndpointRules() []string {
+	if v.config != nil && len(v.config.BlockedEndpoints) > 0 {
+		return v.config.BlockedEndpoints
+	}
+
+	return config.DefaultBlockedGHAPIEndpoints()
+}
+
+// blockedMutations returns the configured GraphQL mutations, or the defaults.
+func (v *APIValidator) blockedMutations() []string {
+	if v.config != nil && len(v.config.BlockedGraphQLMutations) > 0 {
+		return v.config.BlockedGraphQLMutations
+	}
+
+	return config.DefaultBlockedGHAPIMutations()
+}
+
+// compileBlockedEndpoints turns "METHOD pattern" rules into matchers. A rule
+// that does not compile is skipped rather than failing the whole hook.
+func compileBlockedEndpoints(specs []string, log logger.Logger) []blockedEndpoint {
+	blocked := make([]blockedEndpoint, 0, len(specs))
+
+	for _, spec := range specs {
+		method, patternStr, found := strings.Cut(strings.TrimSpace(spec), " ")
+		if !found {
+			log.Error("Ignoring gh api rule without a method", "rule", spec)
+
+			continue
+		}
+
+		pattern, err := rules.CompilePattern(strings.TrimSpace(patternStr))
+		if err != nil {
+			log.Error("Ignoring gh api rule with an invalid pattern", "rule", spec, "error", err)
+
+			continue
+		}
+
+		blocked = append(blocked, blockedEndpoint{
+			method:  strings.ToUpper(method),
+			pattern: pattern,
+		})
+	}
+
+	return blocked
+}
+
+// Validate rejects gh api invocations that would create a commit.
+func (v *APIValidator) Validate(ctx context.Context, hookCtx *hook.Context) *validator.Result {
+	log := v.Logger()
+	log.Debug("Running gh api validation")
+
+	if result := v.CheckRules(ctx, hookCtx); result != nil {
+		return result
+	}
+
+	bashParser := parser.NewBashParser()
+
+	parsed, err := bashParser.Parse(hookCtx.GetCommand())
+	if err != nil {
+		log.Error("Failed to parse command", "error", err)
+
+		return validator.Warn(fmt.Sprintf("Failed to parse command: %v", err))
+	}
+
+	for _, cmd := range parsed.Commands {
+		if !parser.IsGHAPI(&cmd) {
+			continue
+		}
+
+		apiCmd, parseErr := parser.ParseGHAPICommand(cmd)
+		if parseErr != nil {
+			log.Debug("Skipping unparseable gh api command", "error", parseErr)
+
+			continue
+		}
+
+		if result := v.checkAPICommand(apiCmd); result != nil {
+			return result
+		}
+	}
+
+	log.Debug("No commit-creating gh api commands found")
+
+	return validator.Pass()
+}
+
+// checkAPICommand returns a failure when the call creates a commit, nil otherwise.
+func (v *APIValidator) checkAPICommand(apiCmd *parser.GHAPICommand) *validator.Result {
+	if apiCmd.IsGraphQL {
+		return v.checkGraphQL(apiCmd)
+	}
+
+	return v.checkREST(apiCmd)
+}
+
+// checkREST matches the request against the blocked endpoint rules.
+func (v *APIValidator) checkREST(apiCmd *parser.GHAPICommand) *validator.Result {
+	if apiCmd.Endpoint == "" {
+		return nil
+	}
+
+	for _, blocked := range v.endpoints {
+		if blocked.method != methodWildcard && blocked.method != apiCmd.Method {
+			continue
+		}
+
+		if !blocked.pattern.Match(apiCmd.Endpoint) {
+			continue
+		}
+
+		return v.fail(fmt.Sprintf(
+			"gh api %s %s creates a commit through the GitHub API, %s",
+			apiCmd.Method, apiCmd.Endpoint, bypassExplanation,
+		))
+	}
+
+	return nil
+}
+
+// checkGraphQL matches the mutation name inside the query body, since the path
+// is always /graphql and carries no signal.
+func (v *APIValidator) checkGraphQL(apiCmd *parser.GHAPICommand) *validator.Result {
+	for _, mutation := range v.mutations {
+		if !strings.Contains(apiCmd.Query, mutation) {
+			continue
+		}
+
+		return v.fail(fmt.Sprintf(
+			"gh api graphql calls the %s mutation, which creates a commit through the GitHub API, %s",
+			mutation,
+			bypassExplanation,
+		))
+	}
+
+	return nil
+}
+
+// fail builds the blocking result. FixHint comes from the suggestions registry.
+func (*APIValidator) fail(message string) *validator.Result {
+	return validator.FailWithRef(validator.RefGHAPICommit, message).
+		AddDetail("help", apiHelp)
+}

--- a/internal/validators/github/api.go
+++ b/internal/validators/github/api.go
@@ -29,6 +29,9 @@ const (
 	// maxRequestBodyBytes caps how much of a request body file is read.
 	maxRequestBodyBytes = 1 << 20
 
+	// maxScriptDepth bounds how far nested shell -c invocations are unwrapped.
+	maxScriptDepth = 3
+
 	// bypassExplanation names what a commit made this way skips.
 	bypassExplanation = "bypassing commit validation (GPG signing, sign-off, conventional commit format)"
 
@@ -64,6 +67,16 @@ var scriptInterpreters = map[string]bool{
 	"zsh":       true,
 	"ksh":       true,
 	"dash":      true,
+}
+
+// shellInterpreters run a command line handed to them after -c, so that script
+// is parsed and checked like any other command line.
+var shellInterpreters = map[string]bool{
+	"sh":   true,
+	"bash": true,
+	"zsh":  true,
+	"ksh":  true,
+	"dash": true,
 }
 
 // blockedEndpoint pairs an HTTP method with a compiled endpoint pattern.
@@ -210,10 +223,8 @@ func (v *APIValidator) Validate(ctx context.Context, hookCtx *hook.Context) *val
 		return validator.Warn(fmt.Sprintf("Failed to parse command: %v", err))
 	}
 
-	for _, cmd := range parsed.Commands {
-		if result := v.checkCommand(parsed, cmd); result != nil {
-			return result
-		}
+	if result := v.checkParsed(parsed, 0); result != nil {
+		return result
 	}
 
 	log.Debug("No commit-creating API calls found")
@@ -221,10 +232,22 @@ func (v *APIValidator) Validate(ctx context.Context, hookCtx *hook.Context) *val
 	return validator.Pass()
 }
 
+// checkParsed checks every command of one parsed command line.
+func (v *APIValidator) checkParsed(parsed *parser.ParseResult, depth int) *validator.Result {
+	for _, cmd := range parsed.Commands {
+		if result := v.checkCommand(parsed, cmd, depth); result != nil {
+			return result
+		}
+	}
+
+	return nil
+}
+
 // checkCommand dispatches one parsed command to the matching request source.
 func (v *APIValidator) checkCommand(
 	parsed *parser.ParseResult,
 	cmd parser.Command,
+	depth int,
 ) *validator.Result {
 	switch {
 	case parser.IsGHAPI(&cmd):
@@ -247,7 +270,11 @@ func (v *APIValidator) checkCommand(
 		return nil
 
 	case v.checksHTTPClients() && scriptInterpreters[cmd.Name]:
-		return v.checkScriptText(scriptText(cmd))
+		if result := v.checkScriptText(scriptText(cmd)); result != nil {
+			return result
+		}
+
+		return v.checkShellScript(cmd, depth)
 
 	default:
 		return nil
@@ -258,6 +285,39 @@ func (v *APIValidator) checkCommand(
 // the arguments or on stdin.
 func scriptText(cmd parser.Command) string {
 	return strings.Join(cmd.Args, " ") + "\n" + cmd.Stdin
+}
+
+// checkShellScript parses the command line a shell was given after -c and
+// checks it, so wrapping a call in sh -c does not hide it.
+func (v *APIValidator) checkShellScript(cmd parser.Command, depth int) *validator.Result {
+	if depth >= maxScriptDepth || !shellInterpreters[cmd.Name] {
+		return nil
+	}
+
+	script := shellScriptArg(cmd)
+	if script == "" {
+		return nil
+	}
+
+	inner, err := parser.NewBashParser().Parse(script)
+	if err != nil {
+		v.Logger().Debug("Cannot parse shell script argument", "error", err)
+
+		return nil
+	}
+
+	return v.checkParsed(inner, depth+1)
+}
+
+// shellScriptArg returns the command line a shell was given after -c.
+func shellScriptArg(cmd parser.Command) string {
+	for i, arg := range cmd.Args {
+		if arg == "-c" && i+1 < len(cmd.Args) {
+			return cmd.Args[i+1]
+		}
+	}
+
+	return ""
 }
 
 // checkAPICommand returns a failure when the call creates a commit, nil otherwise.
@@ -286,7 +346,7 @@ func (v *APIValidator) checkREST(
 		))
 	}
 
-	if v.isOpaqueWrite(apiCmd, endpoint) {
+	if v.isOpaqueWrite(apiCmd.Method, endpoint) {
 		return v.failUnverifiable(fmt.Sprintf(
 			"gh api %s %s cannot be checked: the endpoint is not spelled literally, "+
 				"so there is no way to tell whether it creates a commit",
@@ -299,8 +359,8 @@ func (v *APIValidator) checkREST(
 
 // isOpaqueWrite reports whether the call changes server state through an
 // endpoint that could not be resolved to a literal path.
-func (v *APIValidator) isOpaqueWrite(apiCmd *parser.GHAPICommand, endpoint string) bool {
-	if !v.blocksUnverifiable() || !apiCmd.IsWriteMethod() {
+func (v *APIValidator) isOpaqueWrite(method, endpoint string) bool {
+	if !v.blocksUnverifiable() || !parser.IsWriteMethod(method) {
 		return false
 	}
 
@@ -441,6 +501,16 @@ func (v *APIValidator) checkHTTPRequest(
 		))
 	}
 
+	// The host is known to be GitHub here, so an unreadable path is as
+	// unprovable as it is for gh api.
+	if v.isOpaqueWrite(req.Method, endpoint) {
+		return v.failUnverifiable(fmt.Sprintf(
+			"%s %s %s cannot be checked: the endpoint is not spelled literally, "+
+				"so there is no way to tell whether it creates a commit",
+			req.Tool, req.Method, describeEndpoint(endpoint),
+		))
+	}
+
 	return nil
 }
 
@@ -453,9 +523,20 @@ func (v *APIValidator) checkRequestBody(
 	body := req.Body
 
 	if req.BodyFile != "" {
-		if content, ok := v.readFile(parsed, req.BodyFile, req.WorkingDirectory, req.Location); ok {
-			body += "\n" + content
+		content, ok := v.readFile(parsed, req.BodyFile, req.WorkingDirectory, req.Location)
+		if !ok {
+			if !v.blocksUnverifiable() {
+				return nil
+			}
+
+			return v.failUnverifiable(fmt.Sprintf(
+				"%s sends a GraphQL body from %s, which cannot be read, "+
+					"so there is no way to tell whether it creates a commit",
+				req.Tool, req.BodyFile,
+			))
 		}
+
+		body += "\n" + content
 	}
 
 	if mutation := v.matchMutation(body); mutation != "" {
@@ -463,6 +544,14 @@ func (v *APIValidator) checkRequestBody(
 			"%s sends the %s mutation to the GitHub GraphQL API, "+
 				"which creates a commit, %s",
 			req.Tool, mutation, bypassExplanation,
+		))
+	}
+
+	if strings.TrimSpace(body) == "" && req.IsWriteMethod() && v.blocksUnverifiable() {
+		return v.failUnverifiable(fmt.Sprintf(
+			"%s sends a GraphQL query that is not spelled out in the command, "+
+				"so there is no way to tell whether it creates a commit",
+			req.Tool,
 		))
 	}
 

--- a/internal/validators/github/api.go
+++ b/internal/validators/github/api.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -32,6 +33,9 @@ const (
 	// API path, which can appear on any hostname.
 	ghesRESTPrefix    = "api/v3/"
 	ghesGraphQLPrefix = "api/graphql"
+
+	// maxRequestBodyBytes caps how much of a request body file is read.
+	maxRequestBodyBytes = 1 << 20
 
 	// bypassExplanation names what a commit made this way skips.
 	bypassExplanation = "bypassing commit validation (GPG signing, sign-off, conventional commit format)"
@@ -342,9 +346,36 @@ func (v *APIValidator) readFile(
 		path = filepath.Join(workDir, path)
 	}
 
-	content, err := os.ReadFile(filepath.Clean(path))
+	return v.readBodyFile(filepath.Clean(path))
+}
+
+// readBodyFile reads at most maxRequestBodyBytes of a regular file. The path
+// comes from the command being validated, so an endless character device such
+// as /dev/zero must not be read to the end, and a body far larger than any
+// GraphQL document carries nothing worth matching.
+func (v *APIValidator) readBodyFile(path string) (string, bool) {
+	log := v.Logger()
+
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() {
+		log.Debug("Skipping API request body file", "path", path, "error", err)
+
+		return "", false
+	}
+
+	//nolint:gosec // path comes from the tool invocation klaudiush is validating
+	file, err := os.Open(path)
 	if err != nil {
-		v.Logger().Debug("Cannot read API request body file", "path", path, "error", err)
+		log.Debug("Cannot open API request body file", "path", path, "error", err)
+
+		return "", false
+	}
+
+	defer func() { _ = file.Close() }()
+
+	content, err := io.ReadAll(io.LimitReader(file, maxRequestBodyBytes))
+	if err != nil {
+		log.Debug("Cannot read API request body file", "path", path, "error", err)
 
 		return "", false
 	}

--- a/internal/validators/github/api.go
+++ b/internal/validators/github/api.go
@@ -42,6 +42,30 @@ const (
 		"with -f query=... or on stdin, so klaudiush can tell whether it creates a commit."
 )
 
+// scriptInterpreters run a program given in their arguments or on their stdin.
+// Only their text is scanned for an API call: any other command's arguments are
+// data, and a commit message or a PR comment that quotes a call is not one.
+var scriptInterpreters = map[string]bool{
+	"node":      true,
+	"nodejs":    true,
+	"deno":      true,
+	"bun":       true,
+	"tsx":       true,
+	"ts-node":   true,
+	"python":    true,
+	"python2":   true,
+	"python3":   true,
+	"ruby":      true,
+	"perl":      true,
+	"php":       true,
+	"osascript": true,
+	"sh":        true,
+	"bash":      true,
+	"zsh":       true,
+	"ksh":       true,
+	"dash":      true,
+}
+
 // blockedEndpoint pairs an HTTP method with a compiled endpoint pattern.
 type blockedEndpoint struct {
 	method  string
@@ -192,10 +216,6 @@ func (v *APIValidator) Validate(ctx context.Context, hookCtx *hook.Context) *val
 		}
 	}
 
-	if result := v.checkScriptText(hookCtx.GetCommand()); result != nil {
-		return result
-	}
-
 	log.Debug("No commit-creating API calls found")
 
 	return validator.Pass()
@@ -226,9 +246,18 @@ func (v *APIValidator) checkCommand(
 
 		return nil
 
+	case v.checksHTTPClients() && scriptInterpreters[cmd.Name]:
+		return v.checkScriptText(scriptText(cmd))
+
 	default:
 		return nil
 	}
+}
+
+// scriptText is the program an interpreter was handed, whether it arrived in
+// the arguments or on stdin.
+func scriptText(cmd parser.Command) string {
+	return strings.Join(cmd.Args, " ") + "\n" + cmd.Stdin
 }
 
 // checkAPICommand returns a failure when the call creates a commit, nil otherwise.
@@ -320,6 +349,15 @@ func (v *APIValidator) checkGraphQL(
 			mutation,
 			bypassExplanation,
 		))
+	}
+
+	// A write whose query never appears in the command - built by command
+	// substitution, say - is as unprovable as one whose file cannot be read.
+	if strings.TrimSpace(query) == "" && apiCmd.IsWriteMethod() && v.blocksUnverifiable() {
+		return v.failUnverifiable(
+			"gh api graphql sends a query that is not spelled out in the command, " +
+				"so there is no way to tell whether it creates a commit",
+		)
 	}
 
 	return nil

--- a/internal/validators/github/api.go
+++ b/internal/validators/github/api.go
@@ -218,12 +218,13 @@ func (v *APIValidator) checkCommand(
 		return v.checkAPICommand(parsed, apiCmd)
 
 	case v.checksHTTPClients() && parser.IsHTTPClient(&cmd):
-		req, ok := parser.ParseHTTPClientCommand(cmd)
-		if !ok {
-			return nil
+		for _, req := range parser.ParseHTTPClientCommands(cmd) {
+			if result := v.checkHTTPRequest(parsed, req); result != nil {
+				return result
+			}
 		}
 
-		return v.checkHTTPRequest(parsed, req)
+		return nil
 
 	default:
 		return nil
@@ -357,14 +358,12 @@ func (v *APIValidator) checkHTTPRequest(
 	parsed *parser.ParseResult,
 	req *parser.HTTPRequest,
 ) *validator.Result {
-	url := parsed.ExpandVars(req.URL)
-
-	host, path := parser.SplitURL(url)
+	host, path := parser.SplitRequestURL(parsed.ExpandVars(req.URL))
 	if !v.isGitHubAPI(host, path) {
 		return nil
 	}
 
-	endpoint := parser.NormalizeAPIEndpoint(url)
+	endpoint := parser.NormalizeAPIEndpoint(path)
 
 	if endpoint == graphqlPath {
 		return v.checkRequestBody(parsed, req)
@@ -421,9 +420,9 @@ func (v *APIValidator) checkScriptText(command string) *validator.Result {
 	}
 
 	for _, req := range parser.FindAPICallsInText(command) {
-		endpoint := parser.NormalizeAPIEndpoint(req.URL)
-
 		host, path := parser.SplitURL(req.URL)
+		endpoint := parser.NormalizeAPIEndpoint(path)
+
 		if host != "" {
 			if !v.isGitHubAPI(host, path) {
 				continue

--- a/internal/validators/github/api_test.go
+++ b/internal/validators/github/api_test.go
@@ -204,6 +204,35 @@ var _ = Describe("APIValidator", func() {
 				"an inline python request",
 				`python3 -c 'requests.put("https://api.github.com/repos/o/r/contents/x", json=b)'`,
 			),
+			Entry(
+				"curl with a token in the userinfo",
+				`curl -X PUT https://x-access-token:$T@api.github.com/repos/o/r/contents/x -d '{}'`,
+			),
+			Entry(
+				"curl with an explicit port",
+				`curl -X PUT https://api.github.com:443/repos/o/r/contents/x -d '{}'`,
+			),
+			Entry(
+				"curl with an upper-case host",
+				`curl -X PUT https://API.GITHUB.COM/repos/o/r/contents/x -d '{}'`,
+			),
+			Entry(
+				"curl with an upper-case scheme",
+				`curl -X PUT HTTPS://api.github.com/repos/o/r/contents/x -d '{}'`,
+			),
+			Entry(
+				"curl with no scheme at all",
+				`curl -X PUT api.github.com/repos/o/r/contents/x -d '{}'`,
+			),
+			Entry(
+				"curl fetching a second URL",
+				`curl -X PUT https://example.com/ok https://api.github.com/repos/o/r/contents/x`,
+			),
+			Entry(
+				"curl with the call in a --next request",
+				`curl https://example.com/ok --next -X PUT `+
+					`https://api.github.com/repos/o/r/contents/x -d '{}'`,
+			),
 		)
 
 		DescribeTable(
@@ -227,6 +256,10 @@ var _ = Describe("APIValidator", func() {
 			Entry(
 				"curl downloading a release asset",
 				`curl -L -o out.tgz https://github.com/o/r/archive/refs/tags/v1.tar.gz`,
+			),
+			Entry(
+				"curl reading GitHub then writing elsewhere",
+				`curl https://api.github.com/repos/o/r/contents/x --next -X PUT https://example.com/ok -d '{}'`,
 			),
 			Entry(
 				"an unrelated route in a script",

--- a/internal/validators/github/api_test.go
+++ b/internal/validators/github/api_test.go
@@ -400,6 +400,30 @@ var _ = Describe("APIValidator", func() {
 				"sh -c running curl",
 				`sh -c "curl -X PUT https://api.github.com/repos/o/r/contents/x -d '{}'"`,
 			),
+			Entry(
+				"a heredoc script on stdin",
+				"bash <<'EOF'\ngh api -X PUT repos/o/r/contents/x -f message=y\nEOF",
+			),
+		)
+
+		DescribeTable(
+			"leaves a shell script that only mentions a call alone",
+			func(command string) {
+				result := apiValidator.Validate(ctx, bashContext(command))
+				Expect(result.Passed).To(BeTrue())
+			},
+			Entry(
+				"a commit message quoting a call",
+				`bash -c 'git commit -sS -m "docs: describe octokit.repos.merge() workaround"'`,
+			),
+			Entry(
+				"an echo quoting a call",
+				`sh -c 'echo "use repos.merge() instead"'`,
+			),
+			Entry(
+				"a PR comment quoting a call",
+				`bash -c 'gh pr comment 1 --body "stop using git.createCommit() here"'`,
+			),
 		)
 
 		It("names the tool that sends the request", func() {

--- a/internal/validators/github/api_test.go
+++ b/internal/validators/github/api_test.go
@@ -90,6 +90,18 @@ var _ = Describe("APIValidator", func() {
 				`gh api https://ghe.example.com/api/graphql `+
 					`-f query='mutation { createCommitOnBranch(input: $i) { url } }'`,
 			),
+			Entry(
+				"git commits POST with the field flag value attached",
+				`gh api repos/o/r/git/commits -fmessage=x -ftree=abc`,
+			),
+			Entry(
+				"merges POST with the field flag value attached",
+				`gh api repos/o/r/merges -Fbase=main -Fhead=topic`,
+			),
+			Entry(
+				"curl with the data flag value attached",
+				`curl -d'{"base":"main"}' https://api.github.com/repos/o/r/merges`,
+			),
 		)
 
 		It("names the method, the endpoint and the intended path", func() {
@@ -239,6 +251,11 @@ var _ = Describe("APIValidator", func() {
 				`curl https://example.com/ok --next -X PUT `+
 					`https://api.github.com/repos/o/r/contents/x -d '{}'`,
 			),
+			Entry(
+				"curl whose second URL carries a query string",
+				`curl -X PUT https://example.com/ok `+
+					`"https://api.github.com/repos/o/r/contents/x?branch=main"`,
+			),
 		)
 
 		DescribeTable(
@@ -274,6 +291,22 @@ var _ = Describe("APIValidator", func() {
 			Entry(
 				"a script mentioning a blocked call without invoking it",
 				`echo "use repos.createOrUpdateFileContents instead of git"`,
+			),
+			Entry(
+				"a commit message describing a blocked call",
+				`git commit -sS -m "docs: describe octokit.repos.merge() workaround"`,
+			),
+			Entry(
+				"a PR comment describing a blocked call",
+				`gh pr comment 1 --body "we should stop using octokit git.createCommit() here"`,
+			),
+			Entry(
+				"an issue comment posted through gh api",
+				`gh api repos/o/r/issues/1/comments -f body='use repos.merge() instead of the API'`,
+			),
+			Entry(
+				"a commit message quoting a client call with a URL",
+				`git commit -sS -m 'fix axios.put("https://api.github.com/repos/o/r/contents/x")'`,
 			),
 			Entry(
 				"curl posting a harmless graphql query",
@@ -418,6 +451,17 @@ var _ = Describe("APIValidator", func() {
 
 			var result *validatorpkg.Result
 			Eventually(done, "5s").Should(Receive(&result))
+			Expect(result.Reference.Code()).To(Equal("GH003"))
+		})
+
+		It("blocks a graphql write whose query text is not visible", func() {
+			// Command substitution renders to nothing, so the query the call
+			// will send cannot be inspected.
+			result := apiValidator.Validate(ctx, bashContext(
+				`gh api graphql -f query="$(cat createCommit.graphql)"`,
+			))
+
+			Expect(result.Passed).To(BeFalse())
 			Expect(result.Reference.Code()).To(Equal("GH003"))
 		})
 

--- a/internal/validators/github/api_test.go
+++ b/internal/validators/github/api_test.go
@@ -139,6 +139,134 @@ var _ = Describe("APIValidator", func() {
 		)
 	})
 
+	Describe("clients other than gh", func() {
+		DescribeTable(
+			"blocks the call",
+			func(command string) {
+				result := apiValidator.Validate(ctx, bashContext(command))
+
+				Expect(result.Passed).To(BeFalse())
+				Expect(result.ShouldBlock).To(BeTrue())
+				Expect(result.Reference.Code()).To(Equal("GH002"))
+			},
+			Entry(
+				"curl with an explicit method",
+				`curl -X PUT -H "Authorization: bearer $T" `+
+					`https://api.github.com/repos/o/r/contents/README.md -d '{"message":"x"}'`,
+			),
+			Entry(
+				"curl with the method attached to the flag",
+				`curl -XDELETE https://api.github.com/repos/o/r/contents/README.md`,
+			),
+			Entry(
+				"curl whose method is implied by --upload-file",
+				`curl -T body.json https://api.github.com/repos/o/r/contents/README.md`,
+			),
+			Entry(
+				"curl whose method is implied by --data",
+				`curl --data '{"base":"main"}' https://api.github.com/repos/o/r/merges`,
+			),
+			Entry(
+				"curl using --url instead of a positional",
+				`curl -X PUT --url https://api.github.com/repos/o/r/contents/x`,
+			),
+			Entry(
+				"curl against GitHub Enterprise Server",
+				`curl -X PUT https://ghe.example.com/api/v3/repos/o/r/contents/x -d '{}'`,
+			),
+			Entry(
+				"wget",
+				`wget --method=PUT --body-data='{"message":"x"}' `+
+					`https://api.github.com/repos/o/r/contents/README.md`,
+			),
+			Entry(
+				"httpie",
+				`http PUT https://api.github.com/repos/o/r/contents/README.md message=x`,
+			),
+			Entry(
+				"xh",
+				`xh DELETE https://api.github.com/repos/o/r/contents/README.md`,
+			),
+			Entry(
+				"curl posting a graphql mutation",
+				`curl -X POST https://api.github.com/graphql `+
+					`-d '{"query":"mutation { createCommitOnBranch(input: $i) { url } }"}'`,
+			),
+			Entry(
+				"an inline octokit script",
+				`node -e 'octokit.rest.repos.createOrUpdateFileContents({owner, repo, path})'`,
+			),
+			Entry(
+				"an inline octokit request call",
+				`node -e 'await octokit.request("PUT /repos/{owner}/{repo}/contents/{path}", opts)'`,
+			),
+			Entry(
+				"an inline python request",
+				`python3 -c 'requests.put("https://api.github.com/repos/o/r/contents/x", json=b)'`,
+			),
+		)
+
+		DescribeTable(
+			"passes the call",
+			func(command string) {
+				result := apiValidator.Validate(ctx, bashContext(command))
+				Expect(result.Passed).To(BeTrue())
+			},
+			Entry(
+				"curl reading contents",
+				`curl https://api.github.com/repos/o/r/contents/README.md`,
+			),
+			Entry(
+				"curl creating a branch ref",
+				`curl -X POST https://api.github.com/repos/o/r/git/refs -d '{"ref":"refs/heads/x"}'`,
+			),
+			Entry(
+				"curl against a host that is not GitHub",
+				`curl -X PUT https://example.com/repos/o/r/contents/README.md -d '{}'`,
+			),
+			Entry(
+				"curl downloading a release asset",
+				`curl -L -o out.tgz https://github.com/o/r/archive/refs/tags/v1.tar.gz`,
+			),
+			Entry(
+				"an unrelated route in a script",
+				`node -e 'app.put("/repos/:id/contents/:path", handler)'`,
+			),
+			Entry(
+				"a script mentioning a blocked call without invoking it",
+				`echo "use repos.createOrUpdateFileContents instead of git"`,
+			),
+			Entry(
+				"curl posting a harmless graphql query",
+				`curl -X POST https://api.github.com/graphql -d '{"query":"query { viewer }"}'`,
+			),
+		)
+
+		It("names the tool that sends the request", func() {
+			result := apiValidator.Validate(ctx, bashContext(
+				`curl -X PUT https://api.github.com/repos/o/r/contents/x -d '{}'`,
+			))
+
+			Expect(result.Message).To(HavePrefix("curl PUT repos/o/r/contents/x"))
+		})
+
+		It("leaves other clients alone when the check is turned off", func() {
+			disabled := false
+			cfg := &config.APIValidatorConfig{CheckHTTPClients: &disabled}
+			apiValidator = github.NewAPIValidator(cfg, logger.NewNoOpLogger(), nil)
+
+			viaCurl := apiValidator.Validate(ctx, bashContext(
+				`curl -X PUT https://api.github.com/repos/o/r/contents/x -d '{}'`,
+			))
+			Expect(viaCurl.Passed).To(BeTrue())
+
+			viaGH := apiValidator.Validate(ctx, bashContext(
+				`gh api -X PUT repos/o/r/contents/x -f message=y`,
+			))
+			Expect(viaGH.Passed).To(BeFalse())
+		})
+	})
+
 	Describe("endpoints built from variables", func() {
 		It("resolves an assignment made on the same command line", func() {
 			result := apiValidator.Validate(ctx, bashContext(

--- a/internal/validators/github/api_test.go
+++ b/internal/validators/github/api_test.go
@@ -340,6 +340,51 @@ var _ = Describe("APIValidator", func() {
 		})
 
 		DescribeTable(
+			"unwraps a command launcher",
+			func(command string) {
+				result := apiValidator.Validate(ctx, bashContext(command))
+
+				Expect(result.Passed).To(BeFalse())
+				Expect(result.Reference.Code()).To(Equal("GH002"))
+			},
+			Entry(
+				"sudo",
+				`sudo gh api -X PUT repos/o/r/contents/x -f message=y`,
+			),
+			Entry(
+				"sudo with its own flags",
+				`sudo -u builder gh api -X PUT repos/o/r/contents/x -f message=y`,
+			),
+			Entry(
+				"env with an assignment",
+				`env GH_TOKEN=x gh api -X PUT repos/o/r/contents/x -f message=y`,
+			),
+			Entry(
+				"timeout with a duration",
+				`timeout 30 curl -X PUT https://api.github.com/repos/o/r/contents/x -d '{}'`,
+			),
+			Entry(
+				"npx running an interpreter",
+				`npx tsx -e 'octokit.repos.createOrUpdateFileContents({})'`,
+			),
+			Entry(
+				"uv run running an interpreter",
+				`uv run python -c 'requests.put("https://api.github.com/repos/o/r/contents/x")'`,
+			),
+		)
+
+		DescribeTable(
+			"leaves a launcher running something else alone",
+			func(command string) {
+				result := apiValidator.Validate(ctx, bashContext(command))
+				Expect(result.Passed).To(BeTrue())
+			},
+			Entry("a launcher with no known command", `sudo systemctl restart nginx`),
+			Entry("a command that only prints one", `echo gh api -X PUT repos/o/r/contents/x`),
+			Entry("a launcher running a read", `sudo gh api repos/o/r/contents/x`),
+		)
+
+		DescribeTable(
 			"unwraps a shell interpreter's script",
 			func(command string) {
 				result := apiValidator.Validate(ctx, bashContext(command))

--- a/internal/validators/github/api_test.go
+++ b/internal/validators/github/api_test.go
@@ -1,0 +1,183 @@
+package github_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/smykla-skalski/klaudiush/internal/validators/github"
+	"github.com/smykla-skalski/klaudiush/pkg/config"
+	"github.com/smykla-skalski/klaudiush/pkg/hook"
+	"github.com/smykla-skalski/klaudiush/pkg/logger"
+)
+
+var _ = Describe("APIValidator", func() {
+	var (
+		apiValidator *github.APIValidator
+		ctx          context.Context
+	)
+
+	bashContext := func(command string) *hook.Context {
+		return &hook.Context{
+			EventType: hook.EventTypePreToolUse,
+			ToolName:  hook.ToolTypeBash,
+			ToolInput: hook.ToolInput{Command: command},
+		}
+	}
+
+	BeforeEach(func() {
+		apiValidator = github.NewAPIValidator(nil, logger.NewNoOpLogger(), nil)
+		ctx = context.Background()
+	})
+
+	Describe("commit-creating calls", func() {
+		DescribeTable(
+			"blocks the call",
+			func(command string) {
+				result := apiValidator.Validate(ctx, bashContext(command))
+
+				Expect(result.Passed).To(BeFalse())
+				Expect(result.ShouldBlock).To(BeTrue())
+				Expect(result.Reference.Code()).To(Equal("GH002"))
+				Expect(result.FixHint).To(ContainSubstring("git commit -sS"))
+			},
+			Entry(
+				"contents PUT",
+				`gh api --method PUT /repos/o/r/contents/README.md -f message=x -f content=y`,
+			),
+			Entry(
+				"contents DELETE",
+				`gh api -X DELETE repos/o/r/contents/README.md -f message=x -f sha=abc`,
+			),
+			Entry(
+				"git commits POST",
+				`gh api repos/o/r/git/commits -f message=x -f tree=abc`,
+			),
+			Entry(
+				"merges POST",
+				`gh api repos/o/r/merges -f base=main -f head=topic`,
+			),
+			Entry(
+				"pull request merge PUT",
+				`gh api --method PUT repos/o/r/pulls/42/merge`,
+			),
+			Entry(
+				"full URL form",
+				`gh api -X PUT https://api.github.com/repos/o/r/contents/x.txt -f message=x`,
+			),
+			Entry(
+				"repository spelled from variables",
+				`gh api -X PUT "repos/$OWNER/$REPO/contents/README.md" -f message=x`,
+			),
+			Entry(
+				"one stage of a pipeline",
+				`gh api -X PUT repos/o/r/contents/README.md -f message=x | jq .commit.sha`,
+			),
+			Entry(
+				"one stage of a compound command",
+				`git status && gh api -X PUT repos/o/r/contents/README.md -f message=x`,
+			),
+			Entry(
+				"graphql createCommitOnBranch",
+				`gh api graphql -f query='mutation { createCommitOnBranch(input: $i) { commit { url } } }'`,
+			),
+		)
+
+		It("names the method, the endpoint and the intended path", func() {
+			result := apiValidator.Validate(
+				ctx,
+				bashContext(`gh api -X PUT repos/o/r/contents/README.md -f message=x`),
+			)
+
+			Expect(result.Message).To(ContainSubstring("PUT repos/o/r/contents/README.md"))
+			Expect(result.Details["help"]).To(ContainSubstring("git commit -sS"))
+		})
+	})
+
+	Describe("calls that create no commit", func() {
+		DescribeTable(
+			"passes the call",
+			func(command string) {
+				result := apiValidator.Validate(ctx, bashContext(command))
+				Expect(result.Passed).To(BeTrue())
+			},
+			Entry(
+				"branch creation",
+				`gh api -X POST repos/o/r/git/refs -f ref=refs/heads/topic -f sha=abc`,
+			),
+			Entry(
+				"reading contents",
+				`gh api repos/o/r/contents/README.md`,
+			),
+			Entry(
+				"reading contents through a pipeline",
+				`gh api repos/o/r/contents/README.md --jq .sha | cat`,
+			),
+			Entry(
+				"listing workflow runs",
+				`gh api repos/o/r/actions/runs`,
+			),
+			Entry(
+				"creating a pull request",
+				`gh api -X POST repos/o/r/pulls -f title=x -f head=topic -f base=main`,
+			),
+			Entry(
+				"a harmless graphql query",
+				`gh api graphql -f query='query { viewer { login } }'`,
+			),
+			Entry(
+				"gh pr create",
+				`gh pr create --title "feat(api): x" --body y`,
+			),
+			Entry(
+				"a plain git commit",
+				`git commit -sS -m "feat(api): x"`,
+			),
+		)
+	})
+
+	Describe("configuration", func() {
+		It("uses the configured endpoint rules instead of the defaults", func() {
+			cfg := &config.APIValidatorConfig{
+				BlockedEndpoints: []string{"POST **/git/refs"},
+			}
+			apiValidator = github.NewAPIValidator(cfg, logger.NewNoOpLogger(), nil)
+
+			blocked := apiValidator.Validate(
+				ctx,
+				bashContext(`gh api -X POST repos/o/r/git/refs -f ref=refs/heads/topic`),
+			)
+			Expect(blocked.Passed).To(BeFalse())
+
+			allowed := apiValidator.Validate(
+				ctx,
+				bashContext(`gh api -X PUT repos/o/r/contents/README.md -f message=x`),
+			)
+			Expect(allowed.Passed).To(BeTrue())
+		})
+
+		It("supports a wildcard method", func() {
+			cfg := &config.APIValidatorConfig{
+				BlockedEndpoints: []string{"* **/contents/**"},
+			}
+			apiValidator = github.NewAPIValidator(cfg, logger.NewNoOpLogger(), nil)
+
+			result := apiValidator.Validate(ctx, bashContext(`gh api repos/o/r/contents/README.md`))
+			Expect(result.Passed).To(BeFalse())
+		})
+
+		It("skips a rule with an invalid pattern instead of failing the hook", func() {
+			cfg := &config.APIValidatorConfig{
+				BlockedEndpoints: []string{"PUT [", "PUT **/contents/**"},
+			}
+			apiValidator = github.NewAPIValidator(cfg, logger.NewNoOpLogger(), nil)
+
+			result := apiValidator.Validate(
+				ctx,
+				bashContext(`gh api -X PUT repos/o/r/contents/README.md`),
+			)
+			Expect(result.Passed).To(BeFalse())
+		})
+	})
+})

--- a/internal/validators/github/api_test.go
+++ b/internal/validators/github/api_test.go
@@ -2,6 +2,8 @@ package github_test
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -137,7 +139,116 @@ var _ = Describe("APIValidator", func() {
 		)
 	})
 
+	Describe("endpoints built from variables", func() {
+		It("resolves an assignment made on the same command line", func() {
+			result := apiValidator.Validate(ctx, bashContext(
+				`EP=repos/o/r/contents/README.md; gh api -X PUT "$EP" -f message=x`,
+			))
+
+			Expect(result.Passed).To(BeFalse())
+			Expect(result.Reference.Code()).To(Equal("GH002"))
+		})
+
+		It("resolves an assignment used as a command prefix", func() {
+			result := apiValidator.Validate(ctx, bashContext(
+				`EP=repos/o/r/merges gh api "$EP" -f base=main -f head=topic`,
+			))
+
+			Expect(result.Passed).To(BeFalse())
+			Expect(result.Reference.Code()).To(Equal("GH002"))
+		})
+
+		It("blocks a write whose endpoint cannot be resolved", func() {
+			result := apiValidator.Validate(
+				ctx,
+				bashContext(`gh api -X PUT "$ENDPOINT" -f message=x`),
+			)
+
+			Expect(result.Passed).To(BeFalse())
+			Expect(result.ShouldBlock).To(BeTrue())
+			Expect(result.Reference.Code()).To(Equal("GH003"))
+		})
+
+		It("allows a read whose endpoint cannot be resolved", func() {
+			result := apiValidator.Validate(ctx, bashContext(`gh api "$ENDPOINT" --jq .sha`))
+			Expect(result.Passed).To(BeTrue())
+		})
+
+		It("allows a resolved write to an endpoint that creates no commit", func() {
+			result := apiValidator.Validate(ctx, bashContext(
+				`EP=repos/o/r/git/refs; gh api -X POST "$EP" -f ref=refs/heads/topic`,
+			))
+			Expect(result.Passed).To(BeTrue())
+		})
+	})
+
+	Describe("GraphQL body in a file", func() {
+		It("reads a file written earlier in the same command line", func() {
+			result := apiValidator.Validate(ctx, bashContext(
+				"cat > query.json <<'EOF'\n"+
+					`{"query": "mutation { createCommitOnBranch(input: $i) { commit { url } } }"}`+
+					"\nEOF\ngh api graphql --input query.json",
+			))
+
+			Expect(result.Passed).To(BeFalse())
+			Expect(result.Reference.Code()).To(Equal("GH002"))
+		})
+
+		It("reads a file that exists on disk", func() {
+			dir := GinkgoT().TempDir()
+			path := filepath.Join(dir, "query.json")
+			Expect(os.WriteFile(
+				path,
+				[]byte(`{"query": "mutation { createCommitOnBranch(input: $i) { url } }"}`),
+				0o600,
+			)).To(Succeed())
+
+			result := apiValidator.Validate(ctx, bashContext(`gh api graphql --input `+path))
+
+			Expect(result.Passed).To(BeFalse())
+			Expect(result.Reference.Code()).To(Equal("GH002"))
+		})
+
+		It("passes a file on disk carrying a harmless query", func() {
+			dir := GinkgoT().TempDir()
+			path := filepath.Join(dir, "query.json")
+			Expect(os.WriteFile(
+				path,
+				[]byte(`{"query": "query { viewer { login } }"}`),
+				0o600,
+			)).To(Succeed())
+
+			result := apiValidator.Validate(ctx, bashContext(`gh api graphql --input `+path))
+			Expect(result.Passed).To(BeTrue())
+		})
+
+		It("blocks when the file cannot be read", func() {
+			result := apiValidator.Validate(ctx, bashContext(`gh api graphql --input missing.json`))
+
+			Expect(result.Passed).To(BeFalse())
+			Expect(result.Reference.Code()).To(Equal("GH003"))
+		})
+	})
+
 	Describe("configuration", func() {
+		It("allows unverifiable writes when the check is turned off", func() {
+			disabled := false
+			cfg := &config.APIValidatorConfig{BlockUnverifiableCalls: &disabled}
+			apiValidator = github.NewAPIValidator(cfg, logger.NewNoOpLogger(), nil)
+
+			opaque := apiValidator.Validate(
+				ctx,
+				bashContext(`gh api -X PUT "$ENDPOINT" -f message=x`),
+			)
+			Expect(opaque.Passed).To(BeTrue())
+
+			unreadable := apiValidator.Validate(
+				ctx,
+				bashContext(`gh api graphql --input missing.json`),
+			)
+			Expect(unreadable.Passed).To(BeTrue())
+		})
+
 		It("uses the configured endpoint rules instead of the defaults", func() {
 			cfg := &config.APIValidatorConfig{
 				BlockedEndpoints: []string{"POST **/git/refs"},

--- a/internal/validators/github/api_test.go
+++ b/internal/validators/github/api_test.go
@@ -383,6 +383,21 @@ var _ = Describe("APIValidator", func() {
 			Expect(result.Passed).To(BeTrue())
 		})
 
+		It("reads a query field pointed at a file with @", func() {
+			dir := GinkgoT().TempDir()
+			path := filepath.Join(dir, "q.graphql")
+			Expect(os.WriteFile(
+				path,
+				[]byte("mutation { createCommitOnBranch(input: $i) { url } }"),
+				0o600,
+			)).To(Succeed())
+
+			result := apiValidator.Validate(ctx, bashContext(`gh api graphql -F query=@`+path))
+
+			Expect(result.Passed).To(BeFalse())
+			Expect(result.Reference.Code()).To(Equal("GH002"))
+		})
+
 		It("blocks when the file cannot be read", func() {
 			result := apiValidator.Validate(ctx, bashContext(`gh api graphql --input missing.json`))
 

--- a/internal/validators/github/api_test.go
+++ b/internal/validators/github/api_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	validatorpkg "github.com/smykla-skalski/klaudiush/internal/validator"
 	"github.com/smykla-skalski/klaudiush/internal/validators/github"
 	"github.com/smykla-skalski/klaudiush/pkg/config"
 	"github.com/smykla-skalski/klaudiush/pkg/hook"
@@ -396,6 +397,23 @@ var _ = Describe("APIValidator", func() {
 
 			Expect(result.Passed).To(BeFalse())
 			Expect(result.Reference.Code()).To(Equal("GH002"))
+		})
+
+		It("does not read an endless character device", func() {
+			done := make(chan *validatorpkg.Result, 1)
+
+			go func() {
+				defer GinkgoRecover()
+
+				done <- apiValidator.Validate(
+					ctx,
+					bashContext(`gh api graphql --input /dev/zero`),
+				)
+			}()
+
+			var result *validatorpkg.Result
+			Eventually(done, "5s").Should(Receive(&result))
+			Expect(result.Reference.Code()).To(Equal("GH003"))
 		})
 
 		It("blocks when the file cannot be read", func() {

--- a/internal/validators/github/api_test.go
+++ b/internal/validators/github/api_test.go
@@ -85,6 +85,11 @@ var _ = Describe("APIValidator", func() {
 				"graphql createCommitOnBranch",
 				`gh api graphql -f query='mutation { createCommitOnBranch(input: $i) { commit { url } } }'`,
 			),
+			Entry(
+				"graphql on GitHub Enterprise Server",
+				`gh api https://ghe.example.com/api/graphql `+
+					`-f query='mutation { createCommitOnBranch(input: $i) { url } }'`,
+			),
 		)
 
 		It("names the method, the endpoint and the intended path", func() {
@@ -460,6 +465,22 @@ var _ = Describe("APIValidator", func() {
 				bashContext(`gh api -X PUT repos/o/r/contents/README.md -f message=x`),
 			)
 			Expect(allowed.Passed).To(BeTrue())
+		})
+
+		It("recognises the GitHub Enterprise Server graphql path", func() {
+			// The client-call scan is narrowed to a name nothing uses, so this
+			// proves the GraphQL path itself is recognised rather than the
+			// mutation name merely being spotted in the command text.
+			cfg := &config.APIValidatorConfig{BlockedClientCalls: []string{"nothing.matches.this"}}
+			apiValidator = github.NewAPIValidator(cfg, logger.NewNoOpLogger(), nil)
+
+			result := apiValidator.Validate(ctx, bashContext(
+				`gh api https://ghe.example.com/api/graphql `+
+					`-f query='mutation { createCommitOnBranch(input: $i) { url } }'`,
+			))
+
+			Expect(result.Passed).To(BeFalse())
+			Expect(result.Reference.Code()).To(Equal("GH002"))
 		})
 
 		It("supports a wildcard method", func() {

--- a/internal/validators/github/api_test.go
+++ b/internal/validators/github/api_test.go
@@ -314,6 +314,49 @@ var _ = Describe("APIValidator", func() {
 			),
 		)
 
+		It("blocks a GitHub write whose path cannot be resolved", func() {
+			result := apiValidator.Validate(ctx, bashContext(
+				`curl -X PUT "https://api.github.com/${ENDPOINT}" -d '{}'`,
+			))
+
+			Expect(result.Passed).To(BeFalse())
+			Expect(result.Reference.Code()).To(Equal("GH003"))
+		})
+
+		It("blocks a graphql write whose body file cannot be read", func() {
+			result := apiValidator.Validate(ctx, bashContext(
+				`curl -X POST https://api.github.com/graphql -d @mutation.json`,
+			))
+
+			Expect(result.Passed).To(BeFalse())
+			Expect(result.Reference.Code()).To(Equal("GH003"))
+		})
+
+		It("leaves an unresolved write to another host alone", func() {
+			result := apiValidator.Validate(ctx, bashContext(
+				`curl -X PUT "https://example.com/${ENDPOINT}" -d '{}'`,
+			))
+			Expect(result.Passed).To(BeTrue())
+		})
+
+		DescribeTable(
+			"unwraps a shell interpreter's script",
+			func(command string) {
+				result := apiValidator.Validate(ctx, bashContext(command))
+
+				Expect(result.Passed).To(BeFalse())
+				Expect(result.Reference.Code()).To(Equal("GH002"))
+			},
+			Entry(
+				"bash -c running gh api",
+				`bash -c 'gh api -X PUT repos/o/r/contents/x -f message=y'`,
+			),
+			Entry(
+				"sh -c running curl",
+				`sh -c "curl -X PUT https://api.github.com/repos/o/r/contents/x -d '{}'"`,
+			),
+		)
+
 		It("names the tool that sends the request", func() {
 			result := apiValidator.Validate(ctx, bashContext(
 				`curl -X PUT https://api.github.com/repos/o/r/contents/x -d '{}'`,

--- a/pkg/config/github.go
+++ b/pkg/config/github.go
@@ -27,6 +27,12 @@ type APIValidatorConfig struct {
 	// query body of a /graphql request.
 	// Default: ["createCommitOnBranch"]
 	BlockedGraphQLMutations []string `json:"blocked_graphql_mutations,omitempty" koanf:"blocked_graphql_mutations" toml:"blocked_graphql_mutations,omitempty"`
+
+	// BlockUnverifiableCalls rejects a write whose endpoint was built from a
+	// variable that cannot be resolved, or whose GraphQL body lives in a file
+	// that cannot be read. Such a call cannot be shown to create no commit.
+	// Default: true
+	BlockUnverifiableCalls *bool `json:"block_unverifiable_calls,omitempty" koanf:"block_unverifiable_calls" toml:"block_unverifiable_calls,omitempty"`
 }
 
 // IssueValidatorConfig configures the gh issue create validator.

--- a/pkg/config/github.go
+++ b/pkg/config/github.go
@@ -5,6 +5,28 @@ package config
 type GitHubConfig struct {
 	// Issue validator configuration
 	Issue *IssueValidatorConfig `json:"issue,omitempty" koanf:"issue" toml:"issue,omitempty"`
+
+	// API validator configuration
+	API *APIValidatorConfig `json:"api,omitempty" koanf:"api" toml:"api,omitempty"`
+}
+
+// APIValidatorConfig configures the gh api validator, which rejects calls to
+// GitHub endpoints that create commits outside git and therefore outside the
+// commit validators.
+type APIValidatorConfig struct {
+	ValidatorConfig `koanf:",squash"`
+
+	// BlockedEndpoints lists "METHOD path-pattern" entries. The method may be
+	// "*" to match any. The pattern is matched against the normalized endpoint
+	// path (no scheme, host, leading slash or query string) and is a glob
+	// unless it contains regex syntax.
+	// Default: the REST endpoints that create commits.
+	BlockedEndpoints []string `json:"blocked_endpoints,omitempty" koanf:"blocked_endpoints" toml:"blocked_endpoints,omitempty"`
+
+	// BlockedGraphQLMutations lists mutation names rejected when found in the
+	// query body of a /graphql request.
+	// Default: ["createCommitOnBranch"]
+	BlockedGraphQLMutations []string `json:"blocked_graphql_mutations,omitempty" koanf:"blocked_graphql_mutations" toml:"blocked_graphql_mutations,omitempty"`
 }
 
 // IssueValidatorConfig configures the gh issue create validator.
@@ -26,4 +48,22 @@ type IssueValidatorConfig struct {
 	// Timeout for markdown linting operations.
 	// Default: 10s
 	Timeout Duration `json:"timeout,omitempty" koanf:"timeout" toml:"timeout,omitempty"`
+}
+
+// DefaultBlockedGHAPIEndpoints returns the REST endpoints that create a commit
+// without running git: writing or deleting repository contents, creating a git
+// commit object, merging a branch, and merging a pull request.
+func DefaultBlockedGHAPIEndpoints() []string {
+	return []string{
+		"PUT **/contents/**",
+		"DELETE **/contents/**",
+		"POST **/git/commits",
+		"POST **/merges",
+		"PUT **/pulls/*/merge",
+	}
+}
+
+// DefaultBlockedGHAPIMutations returns the GraphQL mutations that create a commit.
+func DefaultBlockedGHAPIMutations() []string {
+	return []string{"createCommitOnBranch"}
 }

--- a/pkg/config/github.go
+++ b/pkg/config/github.go
@@ -33,6 +33,22 @@ type APIValidatorConfig struct {
 	// that cannot be read. Such a call cannot be shown to create no commit.
 	// Default: true
 	BlockUnverifiableCalls *bool `json:"block_unverifiable_calls,omitempty" koanf:"block_unverifiable_calls" toml:"block_unverifiable_calls,omitempty"`
+
+	// CheckHTTPClients extends the same endpoint rules to curl, wget, httpie
+	// and xh, and to REST calls written inside inline script bodies.
+	// Default: true
+	CheckHTTPClients *bool `json:"check_http_clients,omitempty" koanf:"check_http_clients" toml:"check_http_clients,omitempty"`
+
+	// Hosts are the hostnames treated as the GitHub API when a non-gh client
+	// sends the request. A path under /api/v3/ or /api/graphql is recognised on
+	// any host, covering GitHub Enterprise Server.
+	// Default: ["api.github.com"]
+	Hosts []string `json:"hosts,omitempty" koanf:"hosts" toml:"hosts,omitempty"`
+
+	// BlockedClientCalls lists API client library methods that create a commit.
+	// A name matches only in call form, so mentioning it in prose is fine.
+	// Default: the Octokit methods behind the blocked REST endpoints.
+	BlockedClientCalls []string `json:"blocked_client_calls,omitempty" koanf:"blocked_client_calls" toml:"blocked_client_calls,omitempty"`
 }
 
 // IssueValidatorConfig configures the gh issue create validator.
@@ -72,4 +88,23 @@ func DefaultBlockedGHAPIEndpoints() []string {
 // DefaultBlockedGHAPIMutations returns the GraphQL mutations that create a commit.
 func DefaultBlockedGHAPIMutations() []string {
 	return []string{"createCommitOnBranch"}
+}
+
+// DefaultGitHubAPIHosts returns the hostnames treated as the GitHub API when a
+// client other than gh sends the request.
+func DefaultGitHubAPIHosts() []string {
+	return []string{"api.github.com"}
+}
+
+// DefaultBlockedGHAPIClientCalls returns the API client library methods that
+// create a commit, named the way Octokit exposes them.
+func DefaultBlockedGHAPIClientCalls() []string {
+	return []string{
+		"repos.createOrUpdateFileContents",
+		"repos.deleteFile",
+		"git.createCommit",
+		"repos.merge",
+		"pulls.merge",
+		"createCommitOnBranch",
+	}
 }

--- a/pkg/config/overrides.go
+++ b/pkg/config/overrides.go
@@ -106,6 +106,7 @@ var CodeToValidator = map[string]string{
 
 	// GitHub CLI codes
 	"GH001": "github.issue",
+	"GH002": "github.api",
 
 	// Plugin codes
 	"PLUG001": validatorPlugins,

--- a/pkg/config/overrides.go
+++ b/pkg/config/overrides.go
@@ -107,6 +107,7 @@ var CodeToValidator = map[string]string{
 	// GitHub CLI codes
 	"GH001": "github.issue",
 	"GH002": "github.api",
+	"GH003": "github.api",
 
 	// Plugin codes
 	"PLUG001": validatorPlugins,

--- a/pkg/parser/apitext.go
+++ b/pkg/parser/apitext.go
@@ -5,10 +5,6 @@ import (
 	"strings"
 )
 
-// ScriptTool is the Tool value of a request found in script text rather than
-// in a recognised client command.
-const ScriptTool = "script"
-
 var (
 	// requestCallPattern matches an SDK call that names the method and path in
 	// one string, the form Octokit's request() takes:
@@ -36,7 +32,6 @@ func FindAPICallsInText(text string) []HTTPRequest {
 
 	for _, match := range requestCalls {
 		requests = append(requests, HTTPRequest{
-			Tool:            ScriptTool,
 			Method:          strings.ToUpper(match[1]),
 			URL:             match[2],
 			ExplicitAPICall: true,
@@ -45,7 +40,6 @@ func FindAPICallsInText(text string) []HTTPRequest {
 
 	for _, match := range methodCalls {
 		requests = append(requests, HTTPRequest{
-			Tool:   ScriptTool,
 			Method: strings.ToUpper(match[1]),
 			URL:    match[2],
 		})

--- a/pkg/parser/apitext.go
+++ b/pkg/parser/apitext.go
@@ -1,0 +1,68 @@
+package parser
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ScriptTool is the Tool value of a request found in script text rather than
+// in a recognised client command.
+const ScriptTool = "script"
+
+var (
+	// requestCallPattern matches an SDK call that names the method and path in
+	// one string, the form Octokit's request() takes:
+	// octokit.request("PUT /repos/{owner}/{repo}/contents/{path}", ...)
+	requestCallPattern = regexp.MustCompile(
+		"(?i)request\\(\\s*[\"'`]\\s*(GET|POST|PUT|PATCH|DELETE)\\s+([^\"'`\\s]+)",
+	)
+
+	// methodCallPattern matches a client method carrying the verb in its name,
+	// the form axios, requests and fetch wrappers take:
+	// axios.put("https://api.github.com/repos/o/r/contents/x", body)
+	methodCallPattern = regexp.MustCompile(
+		"(?i)\\.(get|post|put|patch|delete)\\(\\s*[\"'`]([^\"'`]+)",
+	)
+)
+
+// FindAPICallsInText finds REST calls written inside script text, so a request
+// made from an inline node or python program is visible even though the shell
+// command itself is only an interpreter invocation.
+func FindAPICallsInText(text string) []HTTPRequest {
+	requestCalls := requestCallPattern.FindAllStringSubmatch(text, -1)
+	methodCalls := methodCallPattern.FindAllStringSubmatch(text, -1)
+
+	requests := make([]HTTPRequest, 0, len(requestCalls)+len(methodCalls))
+
+	for _, match := range requestCalls {
+		requests = append(requests, HTTPRequest{
+			Tool:            ScriptTool,
+			Method:          strings.ToUpper(match[1]),
+			URL:             match[2],
+			ExplicitAPICall: true,
+		})
+	}
+
+	for _, match := range methodCalls {
+		requests = append(requests, HTTPRequest{
+			Tool:   ScriptTool,
+			Method: strings.ToUpper(match[1]),
+			URL:    match[2],
+		})
+	}
+
+	return requests
+}
+
+// FindCallsInText reports which of the given library call names appear in the
+// text in call form, so "repos.createOrUpdateFileContents" matches only when it
+// is actually invoked and not when it is merely mentioned.
+func FindCallsInText(text string, calls []string) string {
+	for _, call := range calls {
+		if strings.Contains(text, call+"(") {
+			return call
+		}
+	}
+
+	return ""
+}

--- a/pkg/parser/assignments_test.go
+++ b/pkg/parser/assignments_test.go
@@ -1,0 +1,63 @@
+package parser_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/smykla-skalski/klaudiush/pkg/parser"
+)
+
+var _ = Describe("Assignments", func() {
+	parse := func(command string) *parser.ParseResult {
+		GinkgoHelper()
+
+		result, err := parser.NewBashParser().Parse(command)
+		Expect(err).NotTo(HaveOccurred())
+
+		return result
+	}
+
+	It("records a standalone assignment", func() {
+		result := parse(`REPO=owner/name; echo done`)
+		Expect(result.Assignments).To(HaveKeyWithValue("REPO", "owner/name"))
+	})
+
+	It("records an assignment used as a command prefix", func() {
+		result := parse(`REPO=owner/name gh api "repos/$REPO"`)
+		Expect(result.Assignments).To(HaveKeyWithValue("REPO", "owner/name"))
+	})
+
+	It("skips an append assignment, whose full value is unknown", func() {
+		result := parse(`PATHS+=/extra; echo done`)
+		Expect(result.Assignments).NotTo(HaveKey("PATHS"))
+	})
+
+	Describe("ExpandVars", func() {
+		It("substitutes a known assignment", func() {
+			result := parse(`REPO=owner/name; echo done`)
+			Expect(result.ExpandVars("repos/${REPO}/contents/x")).
+				To(Equal("repos/owner/name/contents/x"))
+		})
+
+		It("resolves an assignment that references another", func() {
+			result := parse(`OWNER=acme; REPO=${OWNER}/widget; echo done`)
+			Expect(result.ExpandVars("repos/${REPO}")).To(Equal("repos/acme/widget"))
+		})
+
+		It("leaves an unknown reference in place", func() {
+			result := parse(`OTHER=x; echo done`)
+			Expect(result.ExpandVars("repos/${REPO}")).To(Equal("repos/${REPO}"))
+			Expect(parser.HasUnresolvedVars(result.ExpandVars("repos/${REPO}"))).To(BeTrue())
+		})
+
+		It("terminates on a self-referential assignment", func() {
+			result := parse(`LOOP=${LOOP}/x; echo done`)
+			Expect(result.ExpandVars("${LOOP}")).To(ContainSubstring("${LOOP}"))
+		})
+
+		It("returns the input unchanged when nothing was assigned", func() {
+			result := parse(`echo done`)
+			Expect(result.ExpandVars("repos/${REPO}")).To(Equal("repos/${REPO}"))
+		})
+	})
+})

--- a/pkg/parser/ast_walker.go
+++ b/pkg/parser/ast_walker.go
@@ -15,6 +15,10 @@ type astWalker struct {
 	// piped echo/printf). Populated when a Stmt or pipeline is visited, then
 	// consumed when the corresponding CallExpr is extracted into a Command.
 	stdinByCall map[*syntax.CallExpr]string
+	// assignments records literal NAME=value assignments, both standalone and
+	// as a prefix on a command, so consumers can resolve a variable used later
+	// in the same command line.
+	assignments map[string]string
 }
 
 // visit is called for each node in the AST.
@@ -330,6 +334,8 @@ func printfEscape(c byte) (byte, bool) {
 
 // extractCommand extracts a command from a CallExpr node.
 func (w *astWalker) extractCommand(call *syntax.CallExpr) {
+	w.extractAssigns(call)
+
 	if len(call.Args) == 0 {
 		return
 	}
@@ -499,6 +505,20 @@ func copiesStdinVerbatim(call *syntax.CallExpr) bool {
 		return wordToString(rest[0]) == "-" // "cat -"
 	default:
 		return false // "cat - -", "cat file", ...
+	}
+}
+
+// extractAssigns records NAME=value assignments carried by a call, whether the
+// call is a bare assignment or a command with assignment prefixes. Appends
+// (NAME+=value) and naked assignments carry no complete value, so they are
+// skipped rather than recorded with a partial one.
+func (w *astWalker) extractAssigns(call *syntax.CallExpr) {
+	for _, assign := range call.Assigns {
+		if assign.Name == nil || assign.Value == nil || assign.Append || assign.Naked {
+			continue
+		}
+
+		w.assignments[assign.Name.Value] = wordToString(assign.Value)
 	}
 }
 

--- a/pkg/parser/bash.go
+++ b/pkg/parser/bash.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/cockroachdb/errors"
@@ -17,9 +18,10 @@ var (
 
 // ParseResult contains the results of parsing a Bash command.
 type ParseResult struct {
-	Commands      []Command   // All commands found
-	FileWrites    []FileWrite // All file write operations
-	GitOperations []Command   // Git commands only
+	Commands      []Command         // All commands found
+	FileWrites    []FileWrite       // All file write operations
+	GitOperations []Command         // Git commands only
+	Assignments   map[string]string // Literal NAME=value assignments
 }
 
 // BashParser parses Bash commands using mvdan.cc/sh.
@@ -49,8 +51,9 @@ func (p *BashParser) Parse(command string) (*ParseResult, error) {
 
 	// Walk the AST to extract commands and file operations
 	walker := &astWalker{
-		commands:   make([]Command, 0),
-		fileWrites: make([]FileWrite, 0),
+		commands:    make([]Command, 0),
+		fileWrites:  make([]FileWrite, 0),
+		assignments: make(map[string]string),
 	}
 
 	syntax.Walk(file, walker.visit)
@@ -68,7 +71,55 @@ func (p *BashParser) Parse(command string) (*ParseResult, error) {
 		Commands:      walker.commands,
 		FileWrites:    walker.fileWrites,
 		GitOperations: gitOps,
+		Assignments:   walker.assignments,
 	}, nil
+}
+
+// maxExpandPasses bounds variable expansion so a self-referential assignment
+// cannot loop.
+const maxExpandPasses = 5
+
+// varRefPattern matches a canonical ${NAME} reference, the form wordToString
+// produces for both $NAME and ${NAME}.
+var varRefPattern = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
+
+// ExpandVars substitutes assignments captured from the same command line into
+// s. References with no known assignment are left as they are, so callers can
+// tell a resolved value from one they still cannot see.
+func (r *ParseResult) ExpandVars(s string) string {
+	if len(r.Assignments) == 0 {
+		return s
+	}
+
+	for range maxExpandPasses {
+		if !strings.Contains(s, "${") {
+			break
+		}
+
+		expanded := varRefPattern.ReplaceAllStringFunc(s, func(ref string) string {
+			name := varRefPattern.FindStringSubmatch(ref)[1]
+
+			if value, ok := r.Assignments[name]; ok {
+				return value
+			}
+
+			return ref
+		})
+
+		if expanded == s {
+			break
+		}
+
+		s = expanded
+	}
+
+	return s
+}
+
+// HasUnresolvedVars reports whether s still carries a variable reference that
+// could not be expanded.
+func HasUnresolvedVars(s string) bool {
+	return strings.Contains(s, "${")
 }
 
 // HasCommand checks if the parse result contains a command with the given name.

--- a/pkg/parser/bash.go
+++ b/pkg/parser/bash.go
@@ -97,9 +97,8 @@ func (r *ParseResult) ExpandVars(s string) string {
 		}
 
 		expanded := varRefPattern.ReplaceAllStringFunc(s, func(ref string) string {
-			name := varRefPattern.FindStringSubmatch(ref)[1]
-
-			if value, ok := r.Assignments[name]; ok {
+			// ref is exactly "${NAME}", so the name is what the braces enclose.
+			if value, ok := r.Assignments[ref[2:len(ref)-1]]; ok {
 				return value
 			}
 

--- a/pkg/parser/gh_api.go
+++ b/pkg/parser/gh_api.go
@@ -138,9 +138,14 @@ type GHAPICommand struct {
 	RawArgs []string
 }
 
+// IsWriteMethod reports whether an HTTP method changes server state.
+func IsWriteMethod(method string) bool {
+	return writeMethods[method]
+}
+
 // IsWriteMethod reports whether the request changes server state.
 func (c *GHAPICommand) IsWriteMethod() bool {
-	return writeMethods[c.Method]
+	return IsWriteMethod(c.Method)
 }
 
 // IsGHAPI checks if a command is a gh api command.

--- a/pkg/parser/gh_api.go
+++ b/pkg/parser/gh_api.go
@@ -44,6 +44,7 @@ const (
 	flagMethodLong  = "--method"
 	flagInput       = "--input"
 	flagHeaderLong  = "--header"
+	flagFieldLong   = "--field"
 
 	// Short flags several clients spell the same way for different options:
 	// -F is gh's --field and curl's --form, -b is gh's --body and curl's
@@ -63,7 +64,7 @@ var ghAPIValueFlags = map[string]bool{
 	"-f":            true,
 	"--raw-field":   true,
 	flagFieldShort:  true,
-	"--field":       true,
+	flagFieldLong:   true,
 	"-H":            true,
 	flagHeaderLong:  true,
 	flagInput:       true,
@@ -82,7 +83,7 @@ var ghAPIFieldFlags = map[string]bool{
 	"-f":           true,
 	"--raw-field":  true,
 	flagFieldShort: true,
-	"--field":      true,
+	flagFieldLong:  true,
 	flagInput:      true,
 }
 
@@ -239,7 +240,9 @@ func (c *GHAPICommand) parseAPIArg(args []string, idx int, state *ghAPIParseStat
 	case ghAPIFieldFlags[name]:
 		state.hasFieldFlag = true
 
-		c.collectQueryField(value)
+		// Only --field/-F expands a leading @ to a file; --raw-field takes the
+		// value literally.
+		c.collectQueryField(value, name == flagFieldShort || name == flagFieldLong)
 	}
 
 	return used
@@ -259,8 +262,19 @@ func (c *GHAPICommand) parseAPIPositional(arg string, state *ghAPIParseState) {
 }
 
 // collectQueryField appends a query=... field value to the GraphQL document.
-func (c *GHAPICommand) collectQueryField(value string) {
-	if !strings.HasPrefix(value, queryFieldPrefix) {
+// When the flag expands a leading @, the value names a file holding the query
+// rather than the query itself.
+func (c *GHAPICommand) collectQueryField(value string, expandsFile bool) {
+	query, isQuery := strings.CutPrefix(value, queryFieldPrefix)
+	if !isQuery {
+		return
+	}
+
+	if path, isFile := strings.CutPrefix(query, "@"); isFile && expandsFile {
+		if path != stdinPath {
+			c.InputFile = path
+		}
+
 		return
 	}
 
@@ -268,7 +282,7 @@ func (c *GHAPICommand) collectQueryField(value string) {
 		c.Query += "\n"
 	}
 
-	c.Query += strings.TrimPrefix(value, queryFieldPrefix)
+	c.Query += query
 }
 
 // splitGHAPIFlag splits --flag=value, -f=value and -fvalue into name and value.

--- a/pkg/parser/gh_api.go
+++ b/pkg/parser/gh_api.go
@@ -288,15 +288,17 @@ func (c *GHAPICommand) collectQueryField(value string, expandsFile bool) {
 // splitGHAPIFlag splits --flag=value, -f=value and -fvalue into name and value.
 // The bool reports whether a value was attached to the flag itself.
 func splitGHAPIFlag(arg string) (string, string, bool) {
-	if name, value, found := strings.Cut(arg, "="); found {
-		return name, value, true
-	}
-
-	// Short flag with an attached value, e.g. -XPUT.
+	// A single-dash flag can carry its value attached, as in -XPUT or
+	// -fmessage=x. That split has to come first: cutting on "=" would read
+	// -fmessage=x as a flag named "-fmessage" and lose the field entirely.
 	if len(arg) > shortFlagLen && !strings.HasPrefix(arg, "--") {
 		if short := arg[:shortFlagLen]; ghAPIValueFlags[short] {
-			return short, arg[shortFlagLen:], true
+			return short, strings.TrimPrefix(arg[shortFlagLen:], "="), true
 		}
+	}
+
+	if name, value, found := strings.Cut(arg, "="); found {
+		return name, value, true
 	}
 
 	return arg, "", false

--- a/pkg/parser/gh_api.go
+++ b/pkg/parser/gh_api.go
@@ -38,6 +38,10 @@ const (
 	flagMethodShort = "-X"
 	flagMethodLong  = "--method"
 	flagFieldShort  = "-F"
+	flagInput       = "--input"
+
+	// stdinPath is the --input value that means "read the body from stdin".
+	stdinPath = "-"
 )
 
 // ghAPIValueFlags lists gh api flags that consume the following argument.
@@ -50,7 +54,7 @@ var ghAPIValueFlags = map[string]bool{
 	"--field":       true,
 	"-H":            true,
 	"--header":      true,
-	"--input":       true,
+	flagInput:       true,
 	"-q":            true,
 	"--jq":          true,
 	"-t":            true,
@@ -67,7 +71,7 @@ var ghAPIFieldFlags = map[string]bool{
 	"--raw-field":  true,
 	flagFieldShort: true,
 	"--field":      true,
-	"--input":      true,
+	flagInput:      true,
 }
 
 // httpMethods lists the verbs accepted as a bare positional method.
@@ -79,6 +83,14 @@ var httpMethods = map[string]bool{
 	"DELETE":  true,
 	"HEAD":    true,
 	"OPTIONS": true,
+}
+
+// writeMethods lists the verbs that change server state.
+var writeMethods = map[string]bool{
+	"POST":   true,
+	"PUT":    true,
+	"PATCH":  true,
+	"DELETE": true,
 }
 
 // GHAPICommand represents a parsed gh api command.
@@ -98,8 +110,24 @@ type GHAPICommand struct {
 	// heredocs and piped stdin.
 	Query string
 
+	// InputFile is the --input path, when the body comes from a file rather
+	// than from a field or stdin. "-" means stdin and is not recorded here.
+	InputFile string
+
+	// WorkingDirectory is the effective directory of the command, for
+	// resolving a relative InputFile.
+	WorkingDirectory string
+
+	// Location is the position of the command in the source.
+	Location Location
+
 	// RawArgs contains all the raw arguments for debugging.
 	RawArgs []string
+}
+
+// IsWriteMethod reports whether the request changes server state.
+func (c *GHAPICommand) IsWriteMethod() bool {
+	return writeMethods[c.Method]
 }
 
 // IsGHAPI checks if a command is a gh api command.
@@ -126,8 +154,10 @@ func ParseGHAPICommand(cmd Command) (*GHAPICommand, error) {
 	}
 
 	api := &GHAPICommand{
-		Query:   cmd.Stdin,
-		RawArgs: cmd.Args,
+		Query:            cmd.Stdin,
+		WorkingDirectory: cmd.WorkingDirectory,
+		Location:         cmd.Location,
+		RawArgs:          cmd.Args,
 	}
 
 	state := ghAPIParseState{}
@@ -188,6 +218,12 @@ func (c *GHAPICommand) parseAPIArg(args []string, idx int, state *ghAPIParseStat
 	switch {
 	case name == flagMethodShort || name == flagMethodLong:
 		state.explicitMethod = strings.ToUpper(value)
+	case name == flagInput:
+		state.hasFieldFlag = true
+
+		if value != stdinPath {
+			c.InputFile = value
+		}
 	case ghAPIFieldFlags[name]:
 		state.hasFieldFlag = true
 

--- a/pkg/parser/gh_api.go
+++ b/pkg/parser/gh_api.go
@@ -21,8 +21,13 @@ const (
 	// ghesAPIPrefix is the REST path prefix on GitHub Enterprise Server.
 	ghesAPIPrefix = "api/v3/"
 
+	// ghesGraphQLPath is the GraphQL path on GitHub Enterprise Server.
+	ghesGraphQLPath = "api/graphql"
+
 	methodGET  = "GET"
 	methodPOST = "POST"
+	methodPUT  = "PUT"
+	methodHEAD = "HEAD"
 
 	// queryFieldPrefix marks the field carrying a GraphQL document.
 	queryFieldPrefix = "query="
@@ -37,8 +42,15 @@ const (
 
 	flagMethodShort = "-X"
 	flagMethodLong  = "--method"
-	flagFieldShort  = "-F"
 	flagInput       = "--input"
+	flagHeaderLong  = "--header"
+
+	// Short flags several clients spell the same way for different options:
+	// -F is gh's --field and curl's --form, -b is gh's --body and curl's
+	// --cookie, -m is gh's --merge and curl's --max-time.
+	flagFieldShort = "-F"
+	flagBodyShort  = "-b"
+	flagMergeShort = "-m"
 
 	// stdinPath is the --input value that means "read the body from stdin".
 	stdinPath = "-"
@@ -53,7 +65,7 @@ var ghAPIValueFlags = map[string]bool{
 	flagFieldShort:  true,
 	"--field":       true,
 	"-H":            true,
-	"--header":      true,
+	flagHeaderLong:  true,
 	flagInput:       true,
 	"-q":            true,
 	"--jq":          true,
@@ -274,6 +286,18 @@ func splitGHAPIFlag(arg string) (string, string, bool) {
 	}
 
 	return arg, "", false
+}
+
+// NormalizeAPIEndpoint strips the scheme, host, API prefix, query string and
+// surrounding slashes so patterns can match a stable path. A GitHub Enterprise
+// GraphQL path collapses to the same "graphql" as the github.com one.
+func NormalizeAPIEndpoint(endpoint string) string {
+	normalized := normalizeGHAPIEndpoint(endpoint)
+	if normalized == ghesGraphQLPath {
+		return graphqlEndpoint
+	}
+
+	return normalized
 }
 
 // normalizeGHAPIEndpoint strips the scheme, host, API prefix, query string and

--- a/pkg/parser/gh_api.go
+++ b/pkg/parser/gh_api.go
@@ -313,8 +313,10 @@ func normalizeGHAPIEndpoint(endpoint string) string {
 			return ""
 		}
 
-		endpoint = strings.TrimPrefix(path, ghesAPIPrefix)
+		endpoint = path
 	}
 
-	return strings.Trim(endpoint, "/")
+	// The Enterprise prefix is stripped after the slashes, so a bare path
+	// carries it out too, not only a full URL.
+	return strings.TrimPrefix(strings.Trim(endpoint, "/"), ghesAPIPrefix)
 }

--- a/pkg/parser/gh_api.go
+++ b/pkg/parser/gh_api.go
@@ -1,0 +1,260 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+// ErrNotGHAPICommand is returned when the gh command is not an api command.
+var ErrNotGHAPICommand = errors.New("not a gh api command")
+
+const (
+	apiSubCmd = "api"
+
+	// minGHAPIArgsLen is the minimum arg count for "gh api".
+	minGHAPIArgsLen = 1
+
+	// graphqlEndpoint is the endpoint gh uses for GraphQL requests.
+	graphqlEndpoint = "graphql"
+
+	// ghesAPIPrefix is the REST path prefix on GitHub Enterprise Server.
+	ghesAPIPrefix = "api/v3/"
+
+	methodGET  = "GET"
+	methodPOST = "POST"
+
+	// queryFieldPrefix marks the field carrying a GraphQL document.
+	queryFieldPrefix = "query="
+
+	schemeSeparator = "://"
+	shortFlagLen    = 2
+
+	// argsPerFlag is what a flag consumes on its own, and
+	// argsPerFlagWithValue what it consumes together with its value.
+	argsPerFlag          = 1
+	argsPerFlagWithValue = 2
+
+	flagMethodShort = "-X"
+	flagMethodLong  = "--method"
+	flagFieldShort  = "-F"
+)
+
+// ghAPIValueFlags lists gh api flags that consume the following argument.
+var ghAPIValueFlags = map[string]bool{
+	flagMethodShort: true,
+	flagMethodLong:  true,
+	"-f":            true,
+	"--raw-field":   true,
+	flagFieldShort:  true,
+	"--field":       true,
+	"-H":            true,
+	"--header":      true,
+	"--input":       true,
+	"-q":            true,
+	"--jq":          true,
+	"-t":            true,
+	"--template":    true,
+	"--hostname":    true,
+	"--cache":       true,
+	"-p":            true,
+	"--preview":     true,
+}
+
+// ghAPIFieldFlags lists gh api flags that turn the default method into POST.
+var ghAPIFieldFlags = map[string]bool{
+	"-f":           true,
+	"--raw-field":  true,
+	flagFieldShort: true,
+	"--field":      true,
+	"--input":      true,
+}
+
+// httpMethods lists the verbs accepted as a bare positional method.
+var httpMethods = map[string]bool{
+	"GET":     true,
+	"POST":    true,
+	"PUT":     true,
+	"PATCH":   true,
+	"DELETE":  true,
+	"HEAD":    true,
+	"OPTIONS": true,
+}
+
+// GHAPICommand represents a parsed gh api command.
+type GHAPICommand struct {
+	// Endpoint is the normalized request path: no scheme, no host, no leading
+	// or trailing slash, no query string.
+	Endpoint string
+
+	// Method is the effective HTTP method, upper-case. gh defaults to GET, or
+	// to POST as soon as any field flag is present.
+	Method string
+
+	// IsGraphQL reports whether the request targets the GraphQL endpoint.
+	IsGraphQL bool
+
+	// Query holds GraphQL document text found in the command: query fields,
+	// heredocs and piped stdin.
+	Query string
+
+	// RawArgs contains all the raw arguments for debugging.
+	RawArgs []string
+}
+
+// IsGHAPI checks if a command is a gh api command.
+func IsGHAPI(cmd *Command) bool {
+	if cmd.Name != ghCLI {
+		return false
+	}
+
+	if len(cmd.Args) < minGHAPIArgsLen {
+		return false
+	}
+
+	return cmd.Args[0] == apiSubCmd
+}
+
+// ParseGHAPICommand parses a Command into a GHAPICommand.
+func ParseGHAPICommand(cmd Command) (*GHAPICommand, error) {
+	if cmd.Name != ghCLI {
+		return nil, ErrNotGHCommand
+	}
+
+	if !IsGHAPI(&cmd) {
+		return nil, ErrNotGHAPICommand
+	}
+
+	api := &GHAPICommand{
+		Query:   cmd.Stdin,
+		RawArgs: cmd.Args,
+	}
+
+	state := ghAPIParseState{}
+
+	args := cmd.Args[1:]
+	for i := 0; i < len(args); {
+		i += api.parseAPIArg(args, i, &state)
+	}
+
+	api.Endpoint = normalizeGHAPIEndpoint(api.Endpoint)
+	api.IsGraphQL = api.Endpoint == graphqlEndpoint
+	api.Method = state.resolveMethod()
+
+	return api, nil
+}
+
+// ghAPIParseState accumulates the signals needed to resolve the method.
+type ghAPIParseState struct {
+	explicitMethod   string
+	positionalMethod string
+	hasFieldFlag     bool
+}
+
+// resolveMethod applies gh's own precedence: an explicit method wins, then a
+// bare positional verb, then POST when fields are present, then GET.
+func (s *ghAPIParseState) resolveMethod() string {
+	switch {
+	case s.explicitMethod != "":
+		return s.explicitMethod
+	case s.positionalMethod != "":
+		return s.positionalMethod
+	case s.hasFieldFlag:
+		return methodPOST
+	default:
+		return methodGET
+	}
+}
+
+// parseAPIArg consumes one argument and returns how many args it used.
+func (c *GHAPICommand) parseAPIArg(args []string, idx int, state *ghAPIParseState) int {
+	arg := args[idx]
+
+	if !strings.HasPrefix(arg, "-") || arg == "-" {
+		c.parseAPIPositional(arg, state)
+
+		return argsPerFlag
+	}
+
+	name, value, attached := splitGHAPIFlag(arg)
+
+	used := argsPerFlag
+
+	if !attached && ghAPIValueFlags[name] && idx+1 < len(args) {
+		value = args[idx+1]
+		used = argsPerFlagWithValue
+	}
+
+	switch {
+	case name == flagMethodShort || name == flagMethodLong:
+		state.explicitMethod = strings.ToUpper(value)
+	case ghAPIFieldFlags[name]:
+		state.hasFieldFlag = true
+
+		c.collectQueryField(value)
+	}
+
+	return used
+}
+
+// parseAPIPositional records a bare verb or the endpoint.
+func (c *GHAPICommand) parseAPIPositional(arg string, state *ghAPIParseState) {
+	if c.Endpoint == "" && state.positionalMethod == "" && httpMethods[strings.ToUpper(arg)] {
+		state.positionalMethod = strings.ToUpper(arg)
+
+		return
+	}
+
+	if c.Endpoint == "" {
+		c.Endpoint = arg
+	}
+}
+
+// collectQueryField appends a query=... field value to the GraphQL document.
+func (c *GHAPICommand) collectQueryField(value string) {
+	if !strings.HasPrefix(value, queryFieldPrefix) {
+		return
+	}
+
+	if c.Query != "" {
+		c.Query += "\n"
+	}
+
+	c.Query += strings.TrimPrefix(value, queryFieldPrefix)
+}
+
+// splitGHAPIFlag splits --flag=value, -f=value and -fvalue into name and value.
+// The bool reports whether a value was attached to the flag itself.
+func splitGHAPIFlag(arg string) (string, string, bool) {
+	if name, value, found := strings.Cut(arg, "="); found {
+		return name, value, true
+	}
+
+	// Short flag with an attached value, e.g. -XPUT.
+	if len(arg) > shortFlagLen && !strings.HasPrefix(arg, "--") {
+		if short := arg[:shortFlagLen]; ghAPIValueFlags[short] {
+			return short, arg[shortFlagLen:], true
+		}
+	}
+
+	return arg, "", false
+}
+
+// normalizeGHAPIEndpoint strips the scheme, host, API prefix, query string and
+// surrounding slashes so patterns can match a stable path.
+func normalizeGHAPIEndpoint(endpoint string) string {
+	if idx := strings.Index(endpoint, "?"); idx != -1 {
+		endpoint = endpoint[:idx]
+	}
+
+	if _, rest, found := strings.Cut(endpoint, schemeSeparator); found {
+		_, path, hasPath := strings.Cut(rest, "/")
+		if !hasPath {
+			return ""
+		}
+
+		endpoint = strings.TrimPrefix(path, ghesAPIPrefix)
+	}
+
+	return strings.Trim(endpoint, "/")
+}

--- a/pkg/parser/gh_api.go
+++ b/pkg/parser/gh_api.go
@@ -15,8 +15,8 @@ const (
 	// minGHAPIArgsLen is the minimum arg count for "gh api".
 	minGHAPIArgsLen = 1
 
-	// graphqlEndpoint is the endpoint gh uses for GraphQL requests.
-	graphqlEndpoint = "graphql"
+	// GraphQLEndpoint is the normalized endpoint of a GraphQL request.
+	GraphQLEndpoint = "graphql"
 
 	// ghesAPIPrefix is the REST path prefix on GitHub Enterprise Server.
 	ghesAPIPrefix = "api/v3/"
@@ -180,8 +180,8 @@ func ParseGHAPICommand(cmd Command) (*GHAPICommand, error) {
 		i += api.parseAPIArg(args, i, &state)
 	}
 
-	api.Endpoint = normalizeGHAPIEndpoint(api.Endpoint)
-	api.IsGraphQL = api.Endpoint == graphqlEndpoint
+	api.Endpoint = NormalizeAPIEndpoint(api.Endpoint)
+	api.IsGraphQL = api.Endpoint == GraphQLEndpoint
 	api.Method = state.resolveMethod()
 
 	return api, nil
@@ -302,21 +302,17 @@ func splitGHAPIFlag(arg string) (string, string, bool) {
 	return arg, "", false
 }
 
+// IsGHESAPIPath reports whether a URL path addresses a GitHub Enterprise
+// Server API, which can live on any hostname.
+func IsGHESAPIPath(path string) bool {
+	return strings.HasPrefix(path, "/"+ghesAPIPrefix) ||
+		strings.HasPrefix(path, "/"+ghesGraphQLPath)
+}
+
 // NormalizeAPIEndpoint strips the scheme, host, API prefix, query string and
 // surrounding slashes so patterns can match a stable path. A GitHub Enterprise
 // GraphQL path collapses to the same "graphql" as the github.com one.
 func NormalizeAPIEndpoint(endpoint string) string {
-	normalized := normalizeGHAPIEndpoint(endpoint)
-	if normalized == ghesGraphQLPath {
-		return graphqlEndpoint
-	}
-
-	return normalized
-}
-
-// normalizeGHAPIEndpoint strips the scheme, host, API prefix, query string and
-// surrounding slashes so patterns can match a stable path.
-func normalizeGHAPIEndpoint(endpoint string) string {
 	if idx := strings.Index(endpoint, "?"); idx != -1 {
 		endpoint = endpoint[:idx]
 	}
@@ -332,5 +328,10 @@ func normalizeGHAPIEndpoint(endpoint string) string {
 
 	// The Enterprise prefix is stripped after the slashes, so a bare path
 	// carries it out too, not only a full URL.
-	return strings.TrimPrefix(strings.Trim(endpoint, "/"), ghesAPIPrefix)
+	normalized := strings.TrimPrefix(strings.Trim(endpoint, "/"), ghesAPIPrefix)
+	if normalized == ghesGraphQLPath {
+		return GraphQLEndpoint
+	}
+
+	return normalized
 }

--- a/pkg/parser/gh_api_test.go
+++ b/pkg/parser/gh_api_test.go
@@ -153,6 +153,25 @@ var _ = Describe("ParseGHAPICommand", func() {
 		})
 	})
 
+	Describe("input file", func() {
+		It("records a --input path", func() {
+			apiCmd, err := parser.ParseGHAPICommand(
+				parseFirstGHCommand("gh api graphql --input query.json"),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(apiCmd.InputFile).To(Equal("query.json"))
+			Expect(apiCmd.Method).To(Equal("POST"))
+		})
+
+		It("treats --input - as stdin rather than a path", func() {
+			apiCmd, err := parser.ParseGHAPICommand(
+				parseFirstGHCommand("gh api graphql --input -"),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(apiCmd.InputFile).To(BeEmpty())
+		})
+	})
+
 	Describe("IsGHAPI", func() {
 		It("recognises gh api inside a pipeline", func() {
 			cmd := parseFirstGHCommand("gh api repos/o/r/commits | jq .")

--- a/pkg/parser/gh_api_test.go
+++ b/pkg/parser/gh_api_test.go
@@ -1,0 +1,167 @@
+package parser_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/smykla-skalski/klaudiush/pkg/parser"
+)
+
+// parseFirstGHCommand parses a shell command and returns the first gh command.
+func parseFirstGHCommand(command string) parser.Command {
+	GinkgoHelper()
+
+	result, err := parser.NewBashParser().Parse(command)
+	Expect(err).NotTo(HaveOccurred())
+
+	commands := result.GetCommands("gh")
+	Expect(commands).NotTo(BeEmpty())
+
+	return commands[0]
+}
+
+var _ = Describe("ParseGHAPICommand", func() {
+	DescribeTable(
+		"resolves the endpoint and effective method",
+		func(command, wantMethod, wantEndpoint string) {
+			apiCmd, err := parser.ParseGHAPICommand(parseFirstGHCommand(command))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(apiCmd.Method).To(Equal(wantMethod))
+			Expect(apiCmd.Endpoint).To(Equal(wantEndpoint))
+		},
+		Entry(
+			"plain read defaults to GET",
+			"gh api repos/o/r/contents/README.md",
+			"GET", "repos/o/r/contents/README.md",
+		),
+		Entry(
+			"leading slash is stripped",
+			"gh api /repos/o/r/contents/README.md",
+			"GET", "repos/o/r/contents/README.md",
+		),
+		Entry(
+			"a field flag makes the default POST",
+			"gh api repos/o/r/merges -f base=main -f head=topic",
+			"POST", "repos/o/r/merges",
+		),
+		Entry(
+			"-X before the endpoint",
+			"gh api -X PUT repos/o/r/contents/README.md",
+			"PUT", "repos/o/r/contents/README.md",
+		),
+		Entry(
+			"-X after the endpoint",
+			"gh api repos/o/r/contents/README.md -X PUT",
+			"PUT", "repos/o/r/contents/README.md",
+		),
+		Entry(
+			"--method=VALUE form",
+			"gh api --method=DELETE repos/o/r/contents/README.md",
+			"DELETE", "repos/o/r/contents/README.md",
+		),
+		Entry(
+			"attached short flag value",
+			"gh api -XPUT repos/o/r/contents/README.md",
+			"PUT", "repos/o/r/contents/README.md",
+		),
+		Entry(
+			"lower-case method is upper-cased",
+			"gh api --method put repos/o/r/contents/README.md",
+			"PUT", "repos/o/r/contents/README.md",
+		),
+		Entry(
+			"bare positional verb",
+			"gh api PUT repos/o/r/contents/README.md",
+			"PUT", "repos/o/r/contents/README.md",
+		),
+		Entry(
+			"full api.github.com URL",
+			"gh api https://api.github.com/repos/o/r/git/commits -f message=x",
+			"POST", "repos/o/r/git/commits",
+		),
+		Entry(
+			"GitHub Enterprise URL drops the api/v3 prefix",
+			"gh api https://ghe.example.com/api/v3/repos/o/r/merges -f base=main",
+			"POST", "repos/o/r/merges",
+		),
+		Entry(
+			"query string is dropped",
+			"gh api 'repos/o/r/commits?per_page=1'",
+			"GET", "repos/o/r/commits",
+		),
+		Entry(
+			"repository spelled from a variable",
+			"gh api -X PUT repos/$OWNER/$REPO/contents/README.md",
+			"PUT", "repos/${OWNER}/${REPO}/contents/README.md",
+		),
+		Entry(
+			"header flag value is not mistaken for the endpoint",
+			"gh api -H 'Accept: application/vnd.github+json' repos/o/r/merges -f base=main",
+			"POST", "repos/o/r/merges",
+		),
+		Entry(
+			"jq flag value is not mistaken for the endpoint",
+			"gh api --jq .sha repos/o/r/commits/main",
+			"GET", "repos/o/r/commits/main",
+		),
+		Entry(
+			"pull request merge",
+			"gh api --method PUT repos/o/r/pulls/42/merge",
+			"PUT", "repos/o/r/pulls/42/merge",
+		),
+	)
+
+	Describe("GraphQL", func() {
+		It("collects the mutation from an inline query field", func() {
+			apiCmd, err := parser.ParseGHAPICommand(parseFirstGHCommand(
+				`gh api graphql -f query='mutation { createCommitOnBranch(input: $i) { commit { url } } }'`,
+			))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(apiCmd.IsGraphQL).To(BeTrue())
+			Expect(apiCmd.Query).To(ContainSubstring("createCommitOnBranch"))
+		})
+
+		It("collects the mutation from a heredoc on stdin", func() {
+			apiCmd, err := parser.ParseGHAPICommand(parseFirstGHCommand(
+				"gh api graphql --input - <<'EOF'\n{\"query\": \"mutation { createCommitOnBranch }\"}\nEOF",
+			))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(apiCmd.IsGraphQL).To(BeTrue())
+			Expect(apiCmd.Query).To(ContainSubstring("createCommitOnBranch"))
+		})
+
+		It("marks the graphql endpoint even with a leading slash", func() {
+			apiCmd, err := parser.ParseGHAPICommand(
+				parseFirstGHCommand("gh api /graphql -f query=x"),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(apiCmd.IsGraphQL).To(BeTrue())
+		})
+	})
+
+	Describe("non-api commands", func() {
+		It("rejects gh pr create", func() {
+			_, err := parser.ParseGHAPICommand(parseFirstGHCommand(`gh pr create --title x`))
+			Expect(err).To(MatchError(parser.ErrNotGHAPICommand))
+		})
+
+		It("rejects a non-gh command", func() {
+			_, err := parser.ParseGHAPICommand(
+				parser.Command{Name: "git", Args: []string{"status"}},
+			)
+			Expect(err).To(MatchError(parser.ErrNotGHCommand))
+		})
+	})
+
+	Describe("IsGHAPI", func() {
+		It("recognises gh api inside a pipeline", func() {
+			cmd := parseFirstGHCommand("gh api repos/o/r/commits | jq .")
+			Expect(parser.IsGHAPI(&cmd)).To(BeTrue())
+		})
+
+		It("does not recognise gh pr merge", func() {
+			cmd := parseFirstGHCommand("gh pr merge 42 --squash")
+			Expect(parser.IsGHAPI(&cmd)).To(BeFalse())
+		})
+	})
+})

--- a/pkg/parser/gh_api_test.go
+++ b/pkg/parser/gh_api_test.go
@@ -163,6 +163,24 @@ var _ = Describe("ParseGHAPICommand", func() {
 			Expect(apiCmd.Method).To(Equal("POST"))
 		})
 
+		It("follows --field query=@path to the file holding the query", func() {
+			apiCmd, err := parser.ParseGHAPICommand(
+				parseFirstGHCommand("gh api graphql -F query=@q.graphql"),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(apiCmd.InputFile).To(Equal("q.graphql"))
+			Expect(apiCmd.Query).To(BeEmpty())
+		})
+
+		It("keeps a --raw-field value literal, since it does not expand @", func() {
+			apiCmd, err := parser.ParseGHAPICommand(
+				parseFirstGHCommand("gh api graphql -f query=@q.graphql"),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(apiCmd.InputFile).To(BeEmpty())
+			Expect(apiCmd.Query).To(Equal("@q.graphql"))
+		})
+
 		It("treats --input - as stdin rather than a path", func() {
 			apiCmd, err := parser.ParseGHAPICommand(
 				parseFirstGHCommand("gh api graphql --input -"),

--- a/pkg/parser/httpclient.go
+++ b/pkg/parser/httpclient.go
@@ -37,7 +37,7 @@ type HTTPRequest struct {
 
 // IsWriteMethod reports whether the request changes server state.
 func (r *HTTPRequest) IsWriteMethod() bool {
-	return writeMethods[r.Method]
+	return IsWriteMethod(r.Method)
 }
 
 // flagRole is what a client flag's value contributes to the request.

--- a/pkg/parser/httpclient.go
+++ b/pkg/parser/httpclient.go
@@ -173,43 +173,83 @@ func IsHTTPClient(cmd *Command) bool {
 	return known
 }
 
-// ParseHTTPClientCommand parses a curl, wget, httpie or xh invocation into the
-// request it sends. The second return is false when the command is not a known
-// client or carries no URL.
-func ParseHTTPClientCommand(cmd Command) (*HTTPRequest, bool) {
+// nextFlag starts a fresh set of curl options, and so a separate request.
+const nextFlag = "--next"
+
+// ParseHTTPClientCommands parses a curl, wget, httpie or xh invocation into
+// every request it sends. One command can carry several: curl fetches each URL
+// it is given, and --next starts a new request with its own options.
+func ParseHTTPClientCommands(cmd Command) []*HTTPRequest {
 	spec, known := httpClientSpecs[cmd.Name]
 	if !known {
-		return nil, false
+		return nil
 	}
 
-	req := &HTTPRequest{
-		Tool:             cmd.Name,
-		Body:             cmd.Stdin,
-		WorkingDirectory: cmd.WorkingDirectory,
-		Location:         cmd.Location,
+	var requests []*HTTPRequest
+
+	for _, segment := range splitOnNext(cmd.Args) {
+		requests = append(requests, parseClientSegment(cmd, &spec, segment)...)
 	}
 
-	state := httpClientState{}
-
-	for i := 0; i < len(cmd.Args); {
-		i += req.parseClientArg(cmd.Args, i, &spec, &state)
-	}
-
-	if req.URL == "" {
-		return nil, false
-	}
-
-	req.Method = state.resolveMethod()
-
-	return req, true
+	return requests
 }
 
-// httpClientState accumulates the signals needed to resolve the method.
+// splitOnNext divides a client's arguments into one group per request.
+func splitOnNext(args []string) [][]string {
+	segments := [][]string{{}}
+
+	for _, arg := range args {
+		if arg == nextFlag {
+			segments = append(segments, []string{})
+
+			continue
+		}
+
+		last := len(segments) - 1
+		segments[last] = append(segments[last], arg)
+	}
+
+	return segments
+}
+
+// parseClientSegment turns one request's arguments into a request per URL. The
+// options in a segment apply to every URL it names, which is how curl treats
+// them.
+func parseClientSegment(cmd Command, spec *httpClientSpec, args []string) []*HTTPRequest {
+	state := httpClientState{}
+
+	for i := 0; i < len(args); {
+		i += state.parseClientArg(args, i, spec)
+	}
+
+	method := state.resolveMethod()
+
+	requests := make([]*HTTPRequest, 0, len(state.urls))
+
+	for _, url := range state.urls {
+		requests = append(requests, &HTTPRequest{
+			Tool:             cmd.Name,
+			Method:           method,
+			URL:              url,
+			Body:             state.body,
+			BodyFile:         state.bodyFile,
+			WorkingDirectory: cmd.WorkingDirectory,
+			Location:         cmd.Location,
+		})
+	}
+
+	return requests
+}
+
+// httpClientState accumulates one request's arguments.
 type httpClientState struct {
 	explicitMethod   string
 	positionalMethod string
 	impliedMethod    string
 	hasDataItem      bool
+	urls             []string
+	body             string
+	bodyFile         string
 }
 
 // resolveMethod applies the precedence every client shares: an explicit method
@@ -230,16 +270,11 @@ func (s *httpClientState) resolveMethod() string {
 }
 
 // parseClientArg consumes one argument and returns how many args it used.
-func (r *HTTPRequest) parseClientArg(
-	args []string,
-	idx int,
-	spec *httpClientSpec,
-	state *httpClientState,
-) int {
+func (s *httpClientState) parseClientArg(args []string, idx int, spec *httpClientSpec) int {
 	arg := args[idx]
 
 	if !strings.HasPrefix(arg, "-") || arg == stdinPath {
-		r.parseClientPositional(arg, spec, state)
+		s.parseClientPositional(arg, spec)
 
 		return argsPerFlag
 	}
@@ -258,74 +293,75 @@ func (r *HTTPRequest) parseClientArg(
 		used = argsPerFlagWithValue
 	}
 
-	r.applyClientFlag(flag, value, state)
+	s.applyClientFlag(flag, value)
 
 	return used
 }
 
 // applyClientFlag records what a single flag says about the request.
-func (r *HTTPRequest) applyClientFlag(
-	flag clientFlag,
-	value string,
-	state *httpClientState,
-) {
-	if flag.implies != "" && state.impliedMethod == "" {
-		state.impliedMethod = flag.implies
+func (s *httpClientState) applyClientFlag(flag clientFlag, value string) {
+	if flag.implies != "" && s.impliedMethod == "" {
+		s.impliedMethod = flag.implies
 	}
 
 	switch flag.role {
 	case roleMethod:
-		state.explicitMethod = strings.ToUpper(value)
+		s.explicitMethod = strings.ToUpper(value)
 	case roleURL:
-		r.URL = value
+		s.urls = append(s.urls, value)
 	case roleBodyFile:
-		r.BodyFile = value
+		s.setBodyFile(value)
 	case roleBody:
-		r.collectBody(value)
+		s.collectBody(value)
 	case roleNone:
 	}
 }
 
-// collectBody records inline body text, following curl's "@path" form to a file.
-func (r *HTTPRequest) collectBody(value string) {
-	if path, isFile := strings.CutPrefix(value, "@"); isFile {
-		r.BodyFile = path
-
+// setBodyFile records a body path, ignoring the stdin marker, whose content is
+// already carried on the command's stdin.
+func (s *httpClientState) setBodyFile(path string) {
+	if path == stdinPath {
 		return
 	}
 
-	if r.Body != "" {
-		r.Body += "\n"
-	}
-
-	r.Body += value
+	s.bodyFile = path
 }
 
-// parseClientPositional records a bare verb, the URL, or an httpie data item.
-func (r *HTTPRequest) parseClientPositional(
-	arg string,
-	spec *httpClientSpec,
-	state *httpClientState,
-) {
-	if spec.positionalMethod && r.URL == "" && state.positionalMethod == "" &&
-		httpMethods[strings.ToUpper(arg)] {
-		state.positionalMethod = strings.ToUpper(arg)
+// collectBody records inline body text, following curl's "@path" form to a file.
+func (s *httpClientState) collectBody(value string) {
+	if path, isFile := strings.CutPrefix(value, "@"); isFile {
+		s.setBodyFile(path)
 
 		return
 	}
 
-	if r.URL == "" {
-		r.URL = arg
+	if s.body != "" {
+		s.body += "\n"
+	}
+
+	s.body += value
+}
+
+// parseClientPositional records a bare verb, a URL, or an httpie data item.
+func (s *httpClientState) parseClientPositional(arg string, spec *httpClientSpec) {
+	if spec.positionalMethod && len(s.urls) == 0 && s.positionalMethod == "" &&
+		httpMethods[strings.ToUpper(arg)] {
+		s.positionalMethod = strings.ToUpper(arg)
 
 		return
 	}
 
 	// httpie request items ("field=value", "field:=json") make the call a POST.
-	if strings.Contains(arg, "=") {
-		state.hasDataItem = true
+	// curl has no positional items, so an "=" only means one once a URL is known.
+	if len(s.urls) > 0 && strings.Contains(arg, "=") {
+		s.hasDataItem = true
 
-		r.collectBody(arg)
+		s.collectBody(arg)
+
+		return
 	}
+
+	s.urls = append(s.urls, arg)
 }
 
 // splitClientFlag splits --flag=value and a short flag with an attached value.
@@ -348,17 +384,70 @@ func splitClientFlag(arg string, spec *httpClientSpec) (string, string, bool) {
 // leading slash so callers can recognise a GitHub Enterprise API prefix. A
 // value with no scheme is treated as a path with no host.
 func SplitURL(raw string) (string, string) {
-	rest, found := strings.CutPrefix(raw, "https://")
+	rest, found := cutScheme(raw)
 	if !found {
-		if rest, found = strings.CutPrefix(raw, "http://"); !found {
-			return "", raw
+		return "", raw
+	}
+
+	authority, path, hasPath := strings.Cut(rest, "/")
+	if !hasPath {
+		return normalizeHost(authority), ""
+	}
+
+	return normalizeHost(authority), "/" + path
+}
+
+// SplitRequestURL is SplitURL for a value a client is about to fetch, where a
+// missing scheme means the client supplies one rather than that the value is a
+// path. Without this, "curl api.github.com/repos/..." would read as hostless.
+func SplitRequestURL(raw string) (string, string) {
+	host, path := SplitURL(raw)
+	if host != "" || !looksLikeHost(raw) {
+		return host, path
+	}
+
+	return SplitURL("https://" + raw)
+}
+
+// looksLikeHost reports whether a scheme-less value starts with something that
+// could be a hostname rather than a path segment.
+func looksLikeHost(raw string) bool {
+	if strings.HasPrefix(raw, "/") {
+		return false
+	}
+
+	authority, _, _ := strings.Cut(raw, "/")
+
+	return strings.Contains(authority, ".")
+}
+
+// cutScheme removes a leading http:// or https://, whatever its case, since a
+// scheme is case-insensitive and curl accepts either spelling.
+func cutScheme(raw string) (string, bool) {
+	lower := strings.ToLower(raw)
+
+	for _, scheme := range []string{"https://", "http://"} {
+		if strings.HasPrefix(lower, scheme) {
+			return raw[len(scheme):], true
 		}
 	}
 
-	host, path, hasPath := strings.Cut(rest, "/")
-	if !hasPath {
-		return host, ""
+	return "", false
+}
+
+// normalizeHost drops the userinfo and the port and lower-cases what is left,
+// so neither a credential prefix nor a spelling defeats a host comparison.
+// An IPv6 literal keeps its brackets and port, which no GitHub host uses.
+func normalizeHost(authority string) string {
+	if at := strings.LastIndex(authority, "@"); at != -1 {
+		authority = authority[at+1:]
 	}
 
-	return host, "/" + path
+	if !strings.HasPrefix(authority, "[") {
+		if host, _, found := strings.Cut(authority, ":"); found {
+			authority = host
+		}
+	}
+
+	return strings.ToLower(authority)
 }

--- a/pkg/parser/httpclient.go
+++ b/pkg/parser/httpclient.go
@@ -1,0 +1,364 @@
+package parser
+
+import (
+	"strings"
+)
+
+// HTTPRequest is an HTTP request found in a shell command, from a client such
+// as curl or wget rather than from gh.
+type HTTPRequest struct {
+	// Tool is the command that sends the request ("curl", "wget", ...).
+	Tool string
+
+	// Method is the effective HTTP method, upper-case.
+	Method string
+
+	// URL is the request target exactly as written.
+	URL string
+
+	// Body holds inline request body text, used to spot a GraphQL mutation.
+	Body string
+
+	// BodyFile is a body read from a file, from "-d @file" or "--body-file".
+	BodyFile string
+
+	// WorkingDirectory is the effective directory of the command.
+	WorkingDirectory string
+
+	// Location is the position of the command in the source.
+	Location Location
+
+	// ExplicitAPICall marks a call whose syntax names an API client, such as
+	// Octokit's request("PUT /repos/..."). Only such a call may be judged on a
+	// path with no host, since any other framework's ".put('/repos/...')" is
+	// just as likely to be a local route.
+	ExplicitAPICall bool
+}
+
+// IsWriteMethod reports whether the request changes server state.
+func (r *HTTPRequest) IsWriteMethod() bool {
+	return writeMethods[r.Method]
+}
+
+// flagRole is what a client flag's value contributes to the request.
+type flagRole uint8
+
+const (
+	roleNone flagRole = iota
+	roleMethod
+	roleBody
+	roleBodyFile
+	roleURL
+)
+
+// clientFlag describes one flag of an HTTP client command.
+type clientFlag struct {
+	// name is the flag as written, including its dashes.
+	name string
+
+	// takesValue marks a flag that consumes the following argument when no
+	// value is attached, so its value cannot be mistaken for the URL.
+	takesValue bool
+
+	// role is what the flag's value means to the request.
+	role flagRole
+
+	// implies is the method the flag's presence selects when none is explicit.
+	implies string
+}
+
+// httpClientSpec describes how one client carries its method, URL and body.
+type httpClientSpec struct {
+	flags []clientFlag
+
+	// positionalMethod allows a bare verb positional to set the method, the
+	// form httpie and xh use.
+	positionalMethod bool
+}
+
+// find returns the descriptor for a flag name.
+func (s *httpClientSpec) find(name string) (clientFlag, bool) {
+	for _, flag := range s.flags {
+		if flag.name == name {
+			return flag, true
+		}
+	}
+
+	return clientFlag{}, false
+}
+
+// curlFlags lists the curl flags that matter, plus the value-taking flags that
+// would otherwise have their value read as the URL.
+var curlFlags = []clientFlag{
+	{name: "-X", takesValue: true, role: roleMethod},
+	{name: "--request", takesValue: true, role: roleMethod},
+	{name: "--url", takesValue: true, role: roleURL},
+	{name: "-d", takesValue: true, role: roleBody, implies: methodPOST},
+	{name: "--data", takesValue: true, role: roleBody, implies: methodPOST},
+	{name: "--data-raw", takesValue: true, role: roleBody, implies: methodPOST},
+	{name: "--data-binary", takesValue: true, role: roleBody, implies: methodPOST},
+	{name: "--data-urlencode", takesValue: true, role: roleBody, implies: methodPOST},
+	{name: "--json", takesValue: true, role: roleBody, implies: methodPOST},
+	{name: flagFieldShort, takesValue: true, role: roleBody, implies: methodPOST},
+	{name: "--form", takesValue: true, role: roleBody, implies: methodPOST},
+	{name: "-T", takesValue: true, role: roleBodyFile, implies: methodPUT},
+	{name: "--upload-file", takesValue: true, role: roleBodyFile, implies: methodPUT},
+	{name: "-I", implies: methodHEAD},
+	{name: "--head", implies: methodHEAD},
+	{name: "-H", takesValue: true},
+	{name: flagHeaderLong, takesValue: true},
+	{name: "-o", takesValue: true},
+	{name: "--output", takesValue: true},
+	{name: "-u", takesValue: true},
+	{name: "--user", takesValue: true},
+	{name: "-A", takesValue: true},
+	{name: "--user-agent", takesValue: true},
+	{name: "-e", takesValue: true},
+	{name: "--referer", takesValue: true},
+	{name: flagBodyShort, takesValue: true},
+	{name: "--cookie", takesValue: true},
+	{name: "-c", takesValue: true},
+	{name: "--cookie-jar", takesValue: true},
+	{name: flagMergeShort, takesValue: true},
+	{name: "--max-time", takesValue: true},
+	{name: "-w", takesValue: true},
+	{name: "--write-out", takesValue: true},
+	{name: "--connect-timeout", takesValue: true},
+	{name: "--retry", takesValue: true},
+	{name: "--resolve", takesValue: true},
+	{name: "--cacert", takesValue: true},
+	{name: "--cert", takesValue: true},
+	{name: "--key", takesValue: true},
+	{name: "--proxy", takesValue: true},
+}
+
+// wgetFlags lists the wget flags that carry the method or a body.
+var wgetFlags = []clientFlag{
+	{name: "--method", takesValue: true, role: roleMethod},
+	{name: "--post-data", takesValue: true, role: roleBody, implies: methodPOST},
+	{name: "--post-file", takesValue: true, role: roleBodyFile, implies: methodPOST},
+	{name: "--body-data", takesValue: true, role: roleBody},
+	{name: "--body-file", takesValue: true, role: roleBodyFile},
+	{name: flagHeaderLong, takesValue: true},
+	{name: "-O", takesValue: true},
+	{name: "--output-document", takesValue: true},
+}
+
+// httpieFlags lists the httpie and xh flags whose value could be read as the
+// URL. Both take the method as a bare positional verb instead of a flag.
+var httpieFlags = []clientFlag{
+	{name: "--raw", takesValue: true, role: roleBody},
+	{name: "-a", takesValue: true},
+	{name: "--auth", takesValue: true},
+	{name: "-A", takesValue: true},
+	{name: "--auth-type", takesValue: true},
+	{name: "-o", takesValue: true},
+	{name: "--output", takesValue: true},
+	{name: "--proxy", takesValue: true},
+}
+
+var httpClientSpecs = map[string]httpClientSpec{
+	"curl":  {flags: curlFlags},
+	"wget":  {flags: wgetFlags},
+	"http":  {flags: httpieFlags, positionalMethod: true},
+	"https": {flags: httpieFlags, positionalMethod: true},
+	"xh":    {flags: httpieFlags, positionalMethod: true},
+	"xhs":   {flags: httpieFlags, positionalMethod: true},
+}
+
+// IsHTTPClient reports whether the command is a known HTTP client.
+func IsHTTPClient(cmd *Command) bool {
+	_, known := httpClientSpecs[cmd.Name]
+
+	return known
+}
+
+// ParseHTTPClientCommand parses a curl, wget, httpie or xh invocation into the
+// request it sends. The second return is false when the command is not a known
+// client or carries no URL.
+func ParseHTTPClientCommand(cmd Command) (*HTTPRequest, bool) {
+	spec, known := httpClientSpecs[cmd.Name]
+	if !known {
+		return nil, false
+	}
+
+	req := &HTTPRequest{
+		Tool:             cmd.Name,
+		Body:             cmd.Stdin,
+		WorkingDirectory: cmd.WorkingDirectory,
+		Location:         cmd.Location,
+	}
+
+	state := httpClientState{}
+
+	for i := 0; i < len(cmd.Args); {
+		i += req.parseClientArg(cmd.Args, i, &spec, &state)
+	}
+
+	if req.URL == "" {
+		return nil, false
+	}
+
+	req.Method = state.resolveMethod()
+
+	return req, true
+}
+
+// httpClientState accumulates the signals needed to resolve the method.
+type httpClientState struct {
+	explicitMethod   string
+	positionalMethod string
+	impliedMethod    string
+	hasDataItem      bool
+}
+
+// resolveMethod applies the precedence every client shares: an explicit method
+// flag, then a bare verb, then what a body flag implies, then GET.
+func (s *httpClientState) resolveMethod() string {
+	switch {
+	case s.explicitMethod != "":
+		return s.explicitMethod
+	case s.positionalMethod != "":
+		return s.positionalMethod
+	case s.impliedMethod != "":
+		return s.impliedMethod
+	case s.hasDataItem:
+		return methodPOST
+	default:
+		return methodGET
+	}
+}
+
+// parseClientArg consumes one argument and returns how many args it used.
+func (r *HTTPRequest) parseClientArg(
+	args []string,
+	idx int,
+	spec *httpClientSpec,
+	state *httpClientState,
+) int {
+	arg := args[idx]
+
+	if !strings.HasPrefix(arg, "-") || arg == stdinPath {
+		r.parseClientPositional(arg, spec, state)
+
+		return argsPerFlag
+	}
+
+	name, value, attached := splitClientFlag(arg, spec)
+
+	flag, known := spec.find(name)
+	if !known {
+		return argsPerFlag
+	}
+
+	used := argsPerFlag
+
+	if !attached && flag.takesValue && idx+1 < len(args) {
+		value = args[idx+1]
+		used = argsPerFlagWithValue
+	}
+
+	r.applyClientFlag(flag, value, state)
+
+	return used
+}
+
+// applyClientFlag records what a single flag says about the request.
+func (r *HTTPRequest) applyClientFlag(
+	flag clientFlag,
+	value string,
+	state *httpClientState,
+) {
+	if flag.implies != "" && state.impliedMethod == "" {
+		state.impliedMethod = flag.implies
+	}
+
+	switch flag.role {
+	case roleMethod:
+		state.explicitMethod = strings.ToUpper(value)
+	case roleURL:
+		r.URL = value
+	case roleBodyFile:
+		r.BodyFile = value
+	case roleBody:
+		r.collectBody(value)
+	case roleNone:
+	}
+}
+
+// collectBody records inline body text, following curl's "@path" form to a file.
+func (r *HTTPRequest) collectBody(value string) {
+	if path, isFile := strings.CutPrefix(value, "@"); isFile {
+		r.BodyFile = path
+
+		return
+	}
+
+	if r.Body != "" {
+		r.Body += "\n"
+	}
+
+	r.Body += value
+}
+
+// parseClientPositional records a bare verb, the URL, or an httpie data item.
+func (r *HTTPRequest) parseClientPositional(
+	arg string,
+	spec *httpClientSpec,
+	state *httpClientState,
+) {
+	if spec.positionalMethod && r.URL == "" && state.positionalMethod == "" &&
+		httpMethods[strings.ToUpper(arg)] {
+		state.positionalMethod = strings.ToUpper(arg)
+
+		return
+	}
+
+	if r.URL == "" {
+		r.URL = arg
+
+		return
+	}
+
+	// httpie request items ("field=value", "field:=json") make the call a POST.
+	if strings.Contains(arg, "=") {
+		state.hasDataItem = true
+
+		r.collectBody(arg)
+	}
+}
+
+// splitClientFlag splits --flag=value and a short flag with an attached value.
+func splitClientFlag(arg string, spec *httpClientSpec) (string, string, bool) {
+	if name, value, found := strings.Cut(arg, "="); found {
+		return name, value, true
+	}
+
+	if len(arg) > shortFlagLen && !strings.HasPrefix(arg, "--") {
+		short := arg[:shortFlagLen]
+		if flag, known := spec.find(short); known && flag.takesValue {
+			return short, arg[shortFlagLen:], true
+		}
+	}
+
+	return arg, "", false
+}
+
+// SplitURL separates a URL into its host and its path. The path keeps its
+// leading slash so callers can recognise a GitHub Enterprise API prefix. A
+// value with no scheme is treated as a path with no host.
+func SplitURL(raw string) (string, string) {
+	rest, found := strings.CutPrefix(raw, "https://")
+	if !found {
+		if rest, found = strings.CutPrefix(raw, "http://"); !found {
+			return "", raw
+		}
+	}
+
+	host, path, hasPath := strings.Cut(rest, "/")
+	if !hasPath {
+		return host, ""
+	}
+
+	return host, "/" + path
+}

--- a/pkg/parser/httpclient.go
+++ b/pkg/parser/httpclient.go
@@ -166,11 +166,16 @@ var httpClientSpecs = map[string]httpClientSpec{
 	"xhs":   {flags: httpieFlags, positionalMethod: true},
 }
 
-// IsHTTPClient reports whether the command is a known HTTP client.
-func IsHTTPClient(cmd *Command) bool {
-	_, known := httpClientSpecs[cmd.Name]
+// IsHTTPClientName reports whether a command name is a known HTTP client.
+func IsHTTPClientName(name string) bool {
+	_, known := httpClientSpecs[name]
 
 	return known
+}
+
+// IsHTTPClient reports whether the command is a known HTTP client.
+func IsHTTPClient(cmd *Command) bool {
+	return IsHTTPClientName(cmd.Name)
 }
 
 // nextFlag starts a fresh set of curl options, and so a separate request.

--- a/pkg/parser/httpclient.go
+++ b/pkg/parser/httpclient.go
@@ -352,8 +352,9 @@ func (s *httpClientState) parseClientPositional(arg string, spec *httpClientSpec
 	}
 
 	// httpie request items ("field=value", "field:=json") make the call a POST.
-	// curl has no positional items, so an "=" only means one once a URL is known.
-	if len(s.urls) > 0 && strings.Contains(arg, "=") {
+	// Only the clients that take a positional method have them; curl fetches
+	// every positional, so a URL of its own carrying a query string stays a URL.
+	if spec.positionalMethod && len(s.urls) > 0 && strings.Contains(arg, "=") {
 		s.hasDataItem = true
 
 		s.collectBody(arg)
@@ -366,15 +367,17 @@ func (s *httpClientState) parseClientPositional(arg string, spec *httpClientSpec
 
 // splitClientFlag splits --flag=value and a short flag with an attached value.
 func splitClientFlag(arg string, spec *httpClientSpec) (string, string, bool) {
-	if name, value, found := strings.Cut(arg, "="); found {
-		return name, value, true
-	}
-
+	// The attached-value split comes first, or "-dbase=main" would read as a
+	// flag named "-dbase" and its body would be lost.
 	if len(arg) > shortFlagLen && !strings.HasPrefix(arg, "--") {
 		short := arg[:shortFlagLen]
 		if flag, known := spec.find(short); known && flag.takesValue {
-			return short, arg[shortFlagLen:], true
+			return short, strings.TrimPrefix(arg[shortFlagLen:], "="), true
 		}
+	}
+
+	if name, value, found := strings.Cut(arg, "="); found {
+		return name, value, true
 	}
 
 	return arg, "", false

--- a/pkg/parser/httpclient_test.go
+++ b/pkg/parser/httpclient_test.go
@@ -1,0 +1,188 @@
+package parser_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/smykla-skalski/klaudiush/pkg/parser"
+)
+
+var _ = Describe("ParseHTTPClientCommand", func() {
+	parseFirst := func(command, name string) parser.Command {
+		GinkgoHelper()
+
+		result, err := parser.NewBashParser().Parse(command)
+		Expect(err).NotTo(HaveOccurred())
+
+		commands := result.GetCommands(name)
+		Expect(commands).NotTo(BeEmpty())
+
+		return commands[0]
+	}
+
+	DescribeTable(
+		"resolves the method and URL",
+		func(command, tool, wantMethod, wantURL string) {
+			req, ok := parser.ParseHTTPClientCommand(parseFirst(command, tool))
+			Expect(ok).To(BeTrue())
+			Expect(req.Method).To(Equal(wantMethod))
+			Expect(req.URL).To(Equal(wantURL))
+		},
+		Entry(
+			"curl defaults to GET",
+			"curl https://api.github.com/repos/o/r/contents/x",
+			"curl", "GET", "https://api.github.com/repos/o/r/contents/x",
+		),
+		Entry(
+			"curl -X before the URL",
+			"curl -X PUT https://api.github.com/repos/o/r/contents/x",
+			"curl", "PUT", "https://api.github.com/repos/o/r/contents/x",
+		),
+		Entry(
+			"curl -X after the URL",
+			"curl https://api.github.com/repos/o/r/contents/x -X DELETE",
+			"curl", "DELETE", "https://api.github.com/repos/o/r/contents/x",
+		),
+		Entry(
+			"curl with the method attached",
+			"curl -XPATCH https://api.github.com/repos/o/r/contents/x",
+			"curl", "PATCH", "https://api.github.com/repos/o/r/contents/x",
+		),
+		Entry(
+			"curl --data implies POST",
+			`curl --data '{"a":1}' https://api.github.com/repos/o/r/merges`,
+			"curl", "POST", "https://api.github.com/repos/o/r/merges",
+		),
+		Entry(
+			"curl --upload-file implies PUT",
+			"curl -T body.json https://api.github.com/repos/o/r/contents/x",
+			"curl", "PUT", "https://api.github.com/repos/o/r/contents/x",
+		),
+		Entry(
+			"curl --url carries the URL",
+			"curl -X PUT --url https://api.github.com/repos/o/r/contents/x",
+			"curl", "PUT", "https://api.github.com/repos/o/r/contents/x",
+		),
+		Entry(
+			"curl header value is not mistaken for the URL",
+			`curl -H "Accept: application/json" https://api.github.com/repos/o/r`,
+			"curl", "GET", "https://api.github.com/repos/o/r",
+		),
+		Entry(
+			"wget --method",
+			"wget --method=PUT --body-data=x https://api.github.com/repos/o/r/contents/x",
+			"wget", "PUT", "https://api.github.com/repos/o/r/contents/x",
+		),
+		Entry(
+			"wget --post-data implies POST",
+			"wget --post-data=x https://api.github.com/repos/o/r/merges",
+			"wget", "POST", "https://api.github.com/repos/o/r/merges",
+		),
+		Entry(
+			"httpie takes the method as a positional",
+			"http PUT https://api.github.com/repos/o/r/contents/x message=y",
+			"http", "PUT", "https://api.github.com/repos/o/r/contents/x",
+		),
+		Entry(
+			"httpie request items imply POST",
+			"http https://api.github.com/repos/o/r/merges base=main head=topic",
+			"http", "POST", "https://api.github.com/repos/o/r/merges",
+		),
+		Entry(
+			"xh takes the method as a positional",
+			"xh DELETE https://api.github.com/repos/o/r/contents/x",
+			"xh", "DELETE", "https://api.github.com/repos/o/r/contents/x",
+		),
+	)
+
+	It("records an inline body", func() {
+		req, ok := parser.ParseHTTPClientCommand(parseFirst(
+			`curl -X POST https://api.github.com/graphql -d '{"query":"mutation {}"}'`, "curl",
+		))
+		Expect(ok).To(BeTrue())
+		Expect(req.Body).To(ContainSubstring("mutation"))
+	})
+
+	It("follows curl's @path form to a body file", func() {
+		req, ok := parser.ParseHTTPClientCommand(parseFirst(
+			"curl -X POST https://api.github.com/graphql -d @query.json", "curl",
+		))
+		Expect(ok).To(BeTrue())
+		Expect(req.BodyFile).To(Equal("query.json"))
+	})
+
+	It("reports no request when the command carries no URL", func() {
+		_, ok := parser.ParseHTTPClientCommand(parseFirst("curl --version", "curl"))
+		Expect(ok).To(BeFalse())
+	})
+
+	It("reports no request for a command that is not a client", func() {
+		_, ok := parser.ParseHTTPClientCommand(
+			parser.Command{Name: "git", Args: []string{"status"}},
+		)
+		Expect(ok).To(BeFalse())
+	})
+
+	Describe("SplitURL", func() {
+		DescribeTable(
+			"separates host from path",
+			func(raw, wantHost, wantPath string) {
+				host, path := parser.SplitURL(raw)
+				Expect(host).To(Equal(wantHost))
+				Expect(path).To(Equal(wantPath))
+			},
+			Entry(
+				"https URL",
+				"https://api.github.com/repos/o/r", "api.github.com", "/repos/o/r",
+			),
+			Entry(
+				"http URL",
+				"http://ghe.example.com/api/v3/repos/o/r", "ghe.example.com", "/api/v3/repos/o/r",
+			),
+			Entry("host with no path", "https://api.github.com", "api.github.com", ""),
+			Entry("bare path", "repos/o/r/contents/x", "", "repos/o/r/contents/x"),
+		)
+	})
+
+	Describe("FindAPICallsInText", func() {
+		It("finds an octokit request call and marks it explicit", func() {
+			calls := parser.FindAPICallsInText(
+				`await octokit.request("PUT /repos/{owner}/{repo}/contents/{path}", opts)`,
+			)
+			Expect(calls).To(HaveLen(1))
+			Expect(calls[0].Method).To(Equal("PUT"))
+			Expect(calls[0].URL).To(Equal("/repos/{owner}/{repo}/contents/{path}"))
+			Expect(calls[0].ExplicitAPICall).To(BeTrue())
+		})
+
+		It("finds a verb-named client method and leaves it implicit", func() {
+			calls := parser.FindAPICallsInText(
+				`axios.put("https://api.github.com/repos/o/r/contents/x", body)`,
+			)
+			Expect(calls).To(HaveLen(1))
+			Expect(calls[0].Method).To(Equal("PUT"))
+			Expect(calls[0].ExplicitAPICall).To(BeFalse())
+		})
+
+		It("finds nothing in text with no call", func() {
+			Expect(parser.FindAPICallsInText("PUT /repos/o/r/contents/x is blocked")).To(BeEmpty())
+		})
+	})
+
+	Describe("FindCallsInText", func() {
+		calls := []string{"repos.createOrUpdateFileContents", "pulls.merge"}
+
+		It("matches a name in call form", func() {
+			Expect(
+				parser.FindCallsInText(`octokit.rest.repos.createOrUpdateFileContents({})`, calls),
+			).
+				To(Equal("repos.createOrUpdateFileContents"))
+		})
+
+		It("ignores a name that is only mentioned", func() {
+			Expect(
+				parser.FindCallsInText("see repos.createOrUpdateFileContents", calls),
+			).To(BeEmpty())
+		})
+	})
+})

--- a/pkg/parser/httpclient_test.go
+++ b/pkg/parser/httpclient_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/smykla-skalski/klaudiush/pkg/parser"
 )
 
-var _ = Describe("ParseHTTPClientCommand", func() {
+var _ = Describe("ParseHTTPClientCommands", func() {
 	parseFirst := func(command, name string) parser.Command {
 		GinkgoHelper()
 
@@ -20,11 +20,19 @@ var _ = Describe("ParseHTTPClientCommand", func() {
 		return commands[0]
 	}
 
+	parseOne := func(command, name string) *parser.HTTPRequest {
+		GinkgoHelper()
+
+		requests := parser.ParseHTTPClientCommands(parseFirst(command, name))
+		Expect(requests).To(HaveLen(1))
+
+		return requests[0]
+	}
+
 	DescribeTable(
 		"resolves the method and URL",
 		func(command, tool, wantMethod, wantURL string) {
-			req, ok := parser.ParseHTTPClientCommand(parseFirst(command, tool))
-			Expect(ok).To(BeTrue())
+			req := parseOne(command, tool)
 			Expect(req.Method).To(Equal(wantMethod))
 			Expect(req.URL).To(Equal(wantURL))
 		},
@@ -96,31 +104,55 @@ var _ = Describe("ParseHTTPClientCommand", func() {
 	)
 
 	It("records an inline body", func() {
-		req, ok := parser.ParseHTTPClientCommand(parseFirst(
+		req := parseOne(
 			`curl -X POST https://api.github.com/graphql -d '{"query":"mutation {}"}'`, "curl",
-		))
-		Expect(ok).To(BeTrue())
+		)
 		Expect(req.Body).To(ContainSubstring("mutation"))
 	})
 
 	It("follows curl's @path form to a body file", func() {
-		req, ok := parser.ParseHTTPClientCommand(parseFirst(
-			"curl -X POST https://api.github.com/graphql -d @query.json", "curl",
-		))
-		Expect(ok).To(BeTrue())
+		req := parseOne("curl -X POST https://api.github.com/graphql -d @query.json", "curl")
 		Expect(req.BodyFile).To(Equal("query.json"))
 	})
 
+	It("treats -d @- as stdin rather than a file named -", func() {
+		req := parseOne("curl -X POST https://api.github.com/graphql -d @-", "curl")
+		Expect(req.BodyFile).To(BeEmpty())
+	})
+
 	It("reports no request when the command carries no URL", func() {
-		_, ok := parser.ParseHTTPClientCommand(parseFirst("curl --version", "curl"))
-		Expect(ok).To(BeFalse())
+		Expect(parser.ParseHTTPClientCommands(parseFirst("curl --version", "curl"))).To(BeEmpty())
 	})
 
 	It("reports no request for a command that is not a client", func() {
-		_, ok := parser.ParseHTTPClientCommand(
+		Expect(parser.ParseHTTPClientCommands(
 			parser.Command{Name: "git", Args: []string{"status"}},
-		)
-		Expect(ok).To(BeFalse())
+		)).To(BeEmpty())
+	})
+
+	Describe("several requests in one command", func() {
+		It("returns one request per URL, sharing the segment's options", func() {
+			requests := parser.ParseHTTPClientCommands(parseFirst(
+				"curl -X PUT https://example.com/a https://api.github.com/repos/o/r/contents/x",
+				"curl",
+			))
+
+			Expect(requests).To(HaveLen(2))
+			Expect(requests[0].URL).To(Equal("https://example.com/a"))
+			Expect(requests[1].URL).To(Equal("https://api.github.com/repos/o/r/contents/x"))
+			Expect(requests[1].Method).To(Equal("PUT"))
+		})
+
+		It("gives each --next segment its own options", func() {
+			requests := parser.ParseHTTPClientCommands(parseFirst(
+				"curl https://example.com/a --next -X DELETE https://api.github.com/repos/o/r/x",
+				"curl",
+			))
+
+			Expect(requests).To(HaveLen(2))
+			Expect(requests[0].Method).To(Equal("GET"))
+			Expect(requests[1].Method).To(Equal("DELETE"))
+		})
 	})
 
 	Describe("SplitURL", func() {
@@ -141,7 +173,39 @@ var _ = Describe("ParseHTTPClientCommand", func() {
 			),
 			Entry("host with no path", "https://api.github.com", "api.github.com", ""),
 			Entry("bare path", "repos/o/r/contents/x", "", "repos/o/r/contents/x"),
+			Entry(
+				"upper-case scheme and host",
+				"HTTPS://API.GITHUB.COM/repos/o/r", "api.github.com", "/repos/o/r",
+			),
+			Entry(
+				"userinfo is dropped",
+				"https://x-token:secret@api.github.com/repos/o/r", "api.github.com", "/repos/o/r",
+			),
+			Entry(
+				"port is dropped",
+				"https://api.github.com:443/repos/o/r", "api.github.com", "/repos/o/r",
+			),
 		)
+	})
+
+	Describe("SplitRequestURL", func() {
+		It("supplies the scheme a client would add", func() {
+			host, path := parser.SplitRequestURL("api.github.com/repos/o/r/contents/x")
+			Expect(host).To(Equal("api.github.com"))
+			Expect(path).To(Equal("/repos/o/r/contents/x"))
+		})
+
+		It("leaves a path that names no host alone", func() {
+			host, path := parser.SplitRequestURL("/repos/o/r/contents/x")
+			Expect(host).To(BeEmpty())
+			Expect(path).To(Equal("/repos/o/r/contents/x"))
+		})
+
+		It("leaves a relative path alone", func() {
+			host, path := parser.SplitRequestURL("repos/o/r/contents/x")
+			Expect(host).To(BeEmpty())
+			Expect(path).To(Equal("repos/o/r/contents/x"))
+		})
 	})
 
 	Describe("FindAPICallsInText", func() {

--- a/schema/config.v1.schema.json
+++ b/schema/config.v1.schema.json
@@ -52,6 +52,9 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "block_unverifiable_calls": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/schema/config.v1.schema.json
+++ b/schema/config.v1.schema.json
@@ -55,6 +55,21 @@
         },
         "block_unverifiable_calls": {
           "type": "boolean"
+        },
+        "check_http_clients": {
+          "type": "boolean"
+        },
+        "hosts": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "blocked_client_calls": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,

--- a/schema/config.v1.schema.json
+++ b/schema/config.v1.schema.json
@@ -30,6 +30,33 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "APIValidatorConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "severity": {
+          "$ref": "#/$defs/Severity"
+        },
+        "rules_enabled": {
+          "type": "boolean"
+        },
+        "blocked_endpoints": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "blocked_graphql_mutations": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "AddValidatorConfig": {
       "properties": {
         "enabled": {
@@ -609,6 +636,9 @@
       "properties": {
         "issue": {
           "$ref": "#/$defs/IssueValidatorConfig"
+        },
+        "api": {
+          "$ref": "#/$defs/APIValidatorConfig"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
# Summary

- New `GH002` validator rejects calls to GitHub endpoints that create a commit without running git, whether they are sent by `gh api`, by `curl`/`wget`/httpie/`xh`, or from an inline script body
- Covers the contents `PUT`/`DELETE` endpoints, `git/commits`, `merges`, `pulls/{n}/merge` and the `createCommitOnBranch` GraphQL mutation
- New `GH003` rejects a `gh api` write whose endpoint or GraphQL body cannot be inspected, so an opaque call is treated as unproven rather than assumed safe
- Everything is configurable under `[validators.github.api]`, and the existing overrides and `EXC:` exception mechanisms apply

## Motivation

klaudiush enforces its commit rules by inspecting `git commit` in Bash. Several GitHub REST and GraphQL endpoints create commits without running git at all, and `gh api` reaches every one of them from the same Bash tool. A commit made that way is invisible to the hook: nothing checks signing, sign-off, the conventional-commit subject, the body line cap, or the ban on PR references.

On 2026-09-04 an agent working in another repository created two commits with `gh api --method PUT` on a contents endpoint. Both landed on the default-branch PR with `verified=false reason=unsigned` and no `Signed-off-by`, on a repository whose whole point is that neither is possible. The same session's `git commit` calls were rejected three times for exactly those rules, so the hook was working - it just never saw these.

Refusing `gh api` wholesale would break ordinary work (creating a branch ref, opening a pull request, reads of any kind) and would get bypassed, which is worse than the hole it closes. So the check matches the specific endpoints that create a commit and leaves everything else alone.

The endpoint is what creates the commit, not the client, so an agent told no by `gh api` reaching for `curl` should meet the same answer. Blocking only `gh` would teach the next bypass rather than close the path.

## Implementation information

- `pkg/parser/gh_api.go` parses a `gh api` invocation into an endpoint and an effective HTTP method, resolving the method the way `gh` itself does: an explicit `-X`/`--method` wins, otherwise `POST` when any field flag is present and `GET` when none is. A known-flag table keeps a `-H` or `--jq` value from being read as the endpoint. The endpoint is normalized by stripping the scheme, host, GitHub Enterprise `api/v3` prefix, leading slash and query string, so the same rule matches `repos/o/r/contents/x`, `/repos/o/r/contents/x` and `https://api.github.com/repos/o/r/contents/x`.
- `pkg/parser/httpclient.go` does the same for `curl`, `wget`, httpie (`http`/`https`) and `xh`, driven by one flag table per client so each client's own method rules are honoured: curl's `--data` implying `POST` and `--upload-file` implying `PUT`, wget's `--method` and `--post-data`, and httpie's bare verb positional and request items.
- `pkg/parser/apitext.go` finds calls written inside an inline script body, so `node -e` and `python3 -c` are not a blind spot. An Octokit `request("PUT /repos/...")` names its own method and path; a verb-named client method such as `axios.put(url)` carries the method in its name. Only the first form is trusted on a path with no host, since `app.put("/repos/:id/...")` is as likely to be a local route.
- `internal/validators/github/api.go` walks every command the bash parser found - so a call inside a pipeline, a `&&` chain or a subshell is seen - and matches each request against the configured rules. A request from a client other than `gh` counts only when its URL addresses the GitHub API: a configured host, or a path under `/api/v3/` or `/api/graphql` on any hostname, which covers Enterprise Server without listing every instance.
- Endpoint rules are `"METHOD path-pattern"` strings, with `*` allowed as the method. Patterns go through `rules.CompilePattern`, so they are globs unless they contain regex syntax, and a rule that fails to compile is skipped rather than failing the hook. The default patterns are tail-anchored (`PUT **/contents/**`), which is what makes a repository spelled from a shell variable still match.
- `pkg/parser/bash.go` now records literal `NAME=value` assignments, both standalone and as a command prefix, and `ExpandVars` resolves them before matching. So `REPO=o/r gh api -X PUT "repos/$REPO/contents/x"` is rejected like the literal form, while a `gh api` write whose endpoint stays opaque falls to GH003. A read through the same variable passes; the stricter rule applies only to `gh api`, where every request goes to GitHub by definition.
- A `--input` GraphQL body, and curl's `-d @file`, are read from the file written earlier in the same command line (via the existing `ParseResult.InlineFileContent`) or from disk. A `gh api` body that cannot be read is GH003.
- Defaults live in both `internal/config/koanf.go` (the map the dispatcher actually loads) and `internal/config/defaults.go`, so the check is on out of the box. `POST **/git/refs` is deliberately absent, so branch creation keeps working.
- Wiring follows the existing `github.issue` validator: reference constants, suggestions entries, the `CodeToValidator` map that makes `klaudiush disable GH002` a known code, the pattern advisor descriptions, a `rules.ValidatorType`, and the `--disable` name map. Exceptions needed no code - `# EXC:GH002:reason` works as soon as the code exists.
- Tests: parser tables over the flag orders, URL forms and variable spellings for both `gh api` and the HTTP clients; validator tables over the blocked and allowed calls including pipeline and compound-command placement; and five dispatcher testscript cases covering a blocked contents write, a blocked GraphQL mutation, a blocked curl and inline octokit script, an opaque write, and the calls that must pass.

## Supporting documentation

- [Issue 615](https://github.com/smykla-skalski/klaudiush/issues/615)
- [docs/errors/GH002.md](https://github.com/smykla-skalski/klaudiush/blob/bartsmykla/feat-github-reject-gh-api-calls-that-create-comm/docs/errors/GH002.md)
- [docs/errors/GH003.md](https://github.com/smykla-skalski/klaudiush/blob/bartsmykla/feat-github-reject-gh-api-calls-that-create-comm/docs/errors/GH003.md)
