### PR TITLE
fix(release): replace release assets on retry

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -114,6 +114,10 @@ release:
   github:
     owner: smykla-skalski
     name: klaudiush
+  # Replace assets rather than append: a release that dies in a late step, such
+  # as the Homebrew formula push, otherwise cannot be retried because every
+  # upload comes back "already_exists".
+  mode: replace
   prerelease: auto
   draft: false
   name_template: 'v{{ .Version }}'


### PR DESCRIPTION
# Summary

- GoReleaser now replaces release assets instead of appending them, so a failed release can be retried

## Motivation

Version 1.39.0 uploaded all fourteen archives, checksums and SBOMs, then failed on the last step, pushing the Homebrew formula. Re-running the job could not get past the upload stage: every asset already existed and the API rejected each one with `422 already_exists`, so the formula push was never reached again.

Recovering meant deleting the published assets by hand before the retry could work. Any release that fails after publishing lands in the same state.

## Implementation information

- `release.mode: replace` deletes an existing asset before uploading its replacement, which makes the publish step idempotent and a retry able to reach whatever failed
